### PR TITLE
Allow user to view own location

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -184,6 +184,7 @@ app.get("/user/:id", async (req, res) => {
     res.json(user);
 });
 
+// update a user's profile
 app.post("/user/:id", async (req, res) => {
     const userId = parseInt(req.params.id);
 
@@ -197,4 +198,26 @@ app.post("/user/:id", async (req, res) => {
     });
 
     res.json(user);
+});
+
+// update a user's location
+app.post("/user/location/:userId", async (req, res) => {
+    const userId = parseInt(req.params.userId);
+
+    await prisma.userLocation.upsert({
+        create: {
+            userId: userId,
+            latitude: req.body.lat,
+            longitude: req.body.lng,
+        },
+        update: {
+            latitude: req.body.lat,
+            longitude: req.body.lng,
+        },
+        where: {
+            userId: userId,
+        },
+    });
+
+    res.send("Successfully updated");
 });

--- a/backend/index.js
+++ b/backend/index.js
@@ -221,3 +221,16 @@ app.post("/user/location/:userId", async (req, res) => {
 
     res.send("Successfully updated");
 });
+
+// remove a user's location data from the database
+app.delete("/user/location/:userId", async (req, res) => {
+    const userId = parseInt(req.params.userId);
+
+    await prisma.userLocation.delete({
+        where: {
+            userId: userId,
+        },
+    });
+
+    res.send("Successfully deleted");
+});

--- a/backend/prisma/migrations/20250625180926_init_location_table/migration.sql
+++ b/backend/prisma/migrations/20250625180926_init_location_table/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `latitude` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `longitude` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "latitude",
+DROP COLUMN "longitude";
+
+-- CreateTable
+CREATE TABLE "UserLocation" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "latitude" DECIMAL(65,30) NOT NULL,
+    "longitude" DECIMAL(65,30) NOT NULL,
+
+    CONSTRAINT "UserLocation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserLocation_userId_key" ON "UserLocation"("userId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,11 @@ model User {
   bio String?
   blockedUsers Int[]
   friends Int[]
-  latitude Decimal?
-  longitude Decimal?
+}
+
+model UserLocation {
+  id Int @id @default(autoincrement())
+  userId Int @unique
+  latitude Decimal
+  longitude Decimal
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
                 "@fortawesome/fontawesome-svg-core": "^6.7.2",
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
                 "@fortawesome/react-fontawesome": "^0.2.2",
+                "@vis.gl/react-google-maps": "^1.5.3",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",
                 "react-router-dom": "^7.6.2"
@@ -1459,6 +1460,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/google.maps": {
+            "version": "3.58.1",
+            "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+            "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+            "license": "MIT"
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1754,6 +1761,20 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@vis.gl/react-google-maps": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.5.3.tgz",
+            "integrity": "sha512-3EX3fXuEnNneuYlg5E3w6G5/o24H5vp/gH068q6tkdWss0M3/dSPVhRCnhUBagT14M8lqvPShjayWOLsLBkLiw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/google.maps": "^3.54.10",
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
             }
         },
         "node_modules/@vitejs/plugin-react": {
@@ -2295,7 +2316,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
+        "@vis.gl/react-google-maps": "^1.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2"

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -61,6 +61,12 @@ const Dashboard = () => {
                         </button>
                     </div>
                 </div>
+                <button
+                    className={styles.mapButton}
+                    onClick={() => navigate("/map")}>
+                    To Map{" "}
+                    <FontAwesomeIcon icon={faArrowRightLong}></FontAwesomeIcon>
+                </button>
             </main>
         );
     }

--- a/frontend/src/components/MapMarker.tsx
+++ b/frontend/src/components/MapMarker.tsx
@@ -1,0 +1,77 @@
+import styles from "../css/MapMarker.module.css";
+import { AdvancedMarker } from "@vis.gl/react-google-maps";
+import { useState, useEffect } from "react";
+import type { UserProfile } from "../types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faUser } from "@fortawesome/free-solid-svg-icons";
+import { getInterestName, getProfile } from "../utils";
+
+interface MapMarkerProps {
+    id: number;
+    location?: google.maps.LatLngLiteral;
+}
+
+/**
+ *
+ * @param id id of the user whom this marker represents (used to fetch profile)
+ * @param location optional; pass in if known (i.e. if this marker represents the current user) to provide most up-to-date info
+ * @returns a marker at the user's location with profile information in a popup on hover
+ */
+const MapMarker = ({ id, location }: MapMarkerProps) => {
+    // profile of the user represented by this marker
+    const [userData, setUserData] = useState<UserProfile>({
+        firstName: "",
+        lastName: "",
+        interests: [],
+    });
+
+    // fetch user's profile to populate popup
+    useEffect(() => {
+        getProfile(id).then((profile) => {
+            if (profile) {
+                setUserData(profile);
+            }
+        });
+    }, []);
+
+    if (location) {
+        return (
+            <AdvancedMarker position={location}>
+                <div className={styles.marker}>
+                    <FontAwesomeIcon
+                        className={styles.markerIcon}
+                        icon={faUser}></FontAwesomeIcon>
+                    <div className={styles.profilePopup}>
+                        <h3 className={styles.profileTitle}>
+                            {userData.firstName} {userData.lastName}{" "}
+                            <span className={styles.profilePronouns}>
+                                {userData.pronouns}
+                            </span>
+                        </h3>
+                        <p className={styles.profileMajor}>
+                            {userData.major ?? "(No major)"}
+                        </p>
+                        <div className={styles.interestsContainer}>
+                            {userData.interests.map((value, index) => {
+                                if (value === 1) {
+                                    return (
+                                        <p className={styles.profileInterest}>
+                                            {getInterestName(index)}
+                                        </p>
+                                    );
+                                } else {
+                                    return <></>;
+                                }
+                            })}
+                        </div>
+                        <p className={styles.profileBio}>{userData.bio}</p>
+                    </div>
+                </div>
+            </AdvancedMarker>
+        );
+    } else {
+        return <></>;
+    }
+};
+
+export default MapMarker;

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -1,0 +1,58 @@
+import styles from "../css/MapPage.module.css";
+import { useUser } from "../contexts/UserContext";
+import { useState, useEffect } from "react";
+import { APIProvider, Map, AdvancedMarker } from "@vis.gl/react-google-maps";
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
+// https://developers.google.com/codelabs/maps-platform/maps-platform-101-react-js#1
+// https://visgl.github.io/react-google-maps/docs/api-reference/components/map
+const MapPage = () => {
+    const { user } = useUser();
+
+    const [myLocation, setMyLocation] =
+        useState<google.maps.LatLngLiteral | null>(null);
+
+    useEffect(() => {
+        const geo = navigator.geolocation;
+        geo.getCurrentPosition((position) => {
+            setMyLocation({
+                lat: position.coords.latitude,
+                lng: position.coords.longitude,
+            });
+        });
+    }, []);
+
+    if (myLocation) {
+        return (
+            <>
+                <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}>
+                    <Map
+                        style={{ width: "100vw", height: "100vh" }}
+                        defaultCenter={myLocation}
+                        mapId={"Users Map"}
+                        defaultZoom={13}
+                        gestureHandling={"greedy"}
+                        disableDefaultUI={true}>
+                        <AdvancedMarker position={myLocation}>
+                            <div className={styles.marker}>
+                                <div className={styles.profilePopup}>
+                                    <h3 className={styles.profileTitle}>
+                                        My Name
+                                    </h3>
+                                </div>
+                            </div>
+                        </AdvancedMarker>
+                    </Map>
+                </APIProvider>
+            </>
+        );
+    } else {
+        return (
+            <>
+                <p>Loading</p>
+            </>
+        );
+    }
+};
+
+export default MapPage;

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -28,13 +28,14 @@ const MapPage = () => {
             });
 
             if (user) {
+                console.log("user");
                 updateLocation(user.id, {
                     lat: position.coords.latitude,
                     lng: position.coords.longitude,
                 });
             }
         });
-    }, []);
+    }, [user]);
 
     if (!user) {
         return <LoggedOut></LoggedOut>;

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -3,20 +3,34 @@ import { useUser } from "../contexts/UserContext";
 import { useState, useEffect } from "react";
 import { APIProvider, Map } from "@vis.gl/react-google-maps";
 import LoggedOut from "./LoggedOut";
-import { updateLocation } from "../utils";
+import { deleteLocation, updateLocation } from "../utils";
 import MapMarker from "./MapMarker";
 import { DEFAULT_MAP_ZOOM } from "../constants";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowLeftLong } from "@fortawesome/free-solid-svg-icons";
+import { useNavigate } from "react-router-dom";
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
 // https://developers.google.com/codelabs/maps-platform/maps-platform-101-react-js#1
 // https://visgl.github.io/react-google-maps/docs/api-reference/components/map
 const MapPage = () => {
+    const navigate = useNavigate();
+
     // logged-in user
     const { user } = useUser();
 
     // location of the current user
     const [myLocation, setMyLocation] =
         useState<google.maps.LatLngLiteral | null>(null);
+
+    // when back button is clicked, remove user's location from active table and navigate to dashboard
+    const handleBack = () => {
+        if (user) {
+            deleteLocation(user.id);
+        }
+
+        navigate("/");
+    };
 
     // fetch current location and save to database
     useEffect(() => {
@@ -42,6 +56,12 @@ const MapPage = () => {
     } else if (myLocation) {
         return (
             <>
+                <button
+                    className={styles.navButton}
+                    onClick={handleBack}>
+                    <FontAwesomeIcon icon={faArrowLeftLong}></FontAwesomeIcon>{" "}
+                    Back to Dashboard
+                </button>
                 <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}>
                     <Map
                         className={styles.map}

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -1,17 +1,24 @@
 import styles from "../css/MapPage.module.css";
 import { useUser } from "../contexts/UserContext";
 import { useState, useEffect } from "react";
-import { APIProvider, Map, AdvancedMarker } from "@vis.gl/react-google-maps";
+import { APIProvider, Map } from "@vis.gl/react-google-maps";
+import LoggedOut from "./LoggedOut";
+import { updateLocation } from "../utils";
+import MapMarker from "./MapMarker";
+import { DEFAULT_MAP_ZOOM } from "../constants";
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
 // https://developers.google.com/codelabs/maps-platform/maps-platform-101-react-js#1
 // https://visgl.github.io/react-google-maps/docs/api-reference/components/map
 const MapPage = () => {
+    // logged-in user
     const { user } = useUser();
 
+    // location of the current user
     const [myLocation, setMyLocation] =
         useState<google.maps.LatLngLiteral | null>(null);
 
+    // fetch current location and save to database
     useEffect(() => {
         const geo = navigator.geolocation;
         geo.getCurrentPosition((position) => {
@@ -19,29 +26,32 @@ const MapPage = () => {
                 lat: position.coords.latitude,
                 lng: position.coords.longitude,
             });
+
+            if (user) {
+                updateLocation(user.id, {
+                    lat: position.coords.latitude,
+                    lng: position.coords.longitude,
+                });
+            }
         });
     }, []);
 
-    if (myLocation) {
+    if (!user) {
+        return <LoggedOut></LoggedOut>;
+    } else if (myLocation) {
         return (
             <>
                 <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}>
                     <Map
-                        style={{ width: "100vw", height: "100vh" }}
+                        className={styles.map}
                         defaultCenter={myLocation}
                         mapId={"Users Map"}
-                        defaultZoom={13}
+                        defaultZoom={DEFAULT_MAP_ZOOM}
                         gestureHandling={"greedy"}
                         disableDefaultUI={true}>
-                        <AdvancedMarker position={myLocation}>
-                            <div className={styles.marker}>
-                                <div className={styles.profilePopup}>
-                                    <h3 className={styles.profileTitle}>
-                                        My Name
-                                    </h3>
-                                </div>
-                            </div>
-                        </AdvancedMarker>
+                        <MapMarker
+                            id={user.id}
+                            location={myLocation}></MapMarker>
                     </Map>
                 </APIProvider>
             </>

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -1,0 +1,4 @@
+/**
+ * Initial zoom level for the map page; ideally shows current and surrounding buildings
+ */
+export const DEFAULT_MAP_ZOOM = 16;

--- a/frontend/src/css/Dashboard.module.css
+++ b/frontend/src/css/Dashboard.module.css
@@ -1,6 +1,7 @@
 .grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
+    height: 100vh;
 }
 
 .titleContainer {
@@ -13,6 +14,7 @@
     gap: 1rem;
     margin: 1rem;
     position: relative;
+    align-self: start;
 }
 
 .title {
@@ -57,7 +59,7 @@
     font-size: 24px;
 }
 
-.button {
+.mapButton {
     background-color: var(--tan-background);
     border: none;
     font-family: inherit;
@@ -65,4 +67,11 @@
     padding: 1rem 2rem;
     border-radius: 2rem;
     color: var(--teal-accent);
+    grid-column-start: 2;
+    grid-column-end: 3;
+    margin: 1rem;
+    height: fit-content;
+    width: fit-content;
+    align-self: end;
+    justify-self: end;
 }

--- a/frontend/src/css/MapMarker.module.css
+++ b/frontend/src/css/MapMarker.module.css
@@ -1,0 +1,73 @@
+.marker {
+    background-color: white;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 100%;
+    border: var(--teal-accent) 0.2rem solid;
+}
+
+.markerIcon {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin: 0.375rem;
+    color: var(--teal-accent);
+}
+
+.profilePopup {
+    display: none;
+    transform: translate(8%, -110%);
+    width: 32rem;
+    height: 16rem;
+    background-color: var(--tan-background);
+    border-radius: 2rem;
+    padding: 2rem;
+    box-sizing: border-box;
+    font-family: Sen, sans-serif;
+    flex-flow: column nowrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.profileTitle {
+    font-family: inherit;
+    font-size: 24px;
+    margin: 0;
+}
+
+.marker:hover .profilePopup {
+    display: flex;
+}
+
+.profilePronouns {
+    font-size: 18px;
+    font-weight: bold;
+    color: var(--teal-accent);
+    margin: 0;
+}
+
+.profileMajor {
+    font-size: 18px;
+    margin: 0;
+}
+
+.interestsContainer {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 0.5rem;
+    font-size: 18px;
+    color: var(--teal-accent);
+}
+
+.profileInterest {
+    margin: 0;
+    border-radius: 1rem;
+    border: var(--teal-accent) 1px solid;
+    padding: 0.25rem 1rem;
+}
+
+.profileBio {
+    font-size: 18px;
+}

--- a/frontend/src/css/MapPage.module.css
+++ b/frontend/src/css/MapPage.module.css
@@ -2,3 +2,16 @@
     width: 100vw;
     height: 100vh;
 }
+
+.navButton {
+    font-family: inherit;
+    font-size: 24px;
+    background-color: var(--tan-background);
+    color: var(--teal-accent);
+    border: none;
+    padding: 1rem 2rem;
+    border-radius: 2rem;
+    margin: 2rem;
+    position: fixed;
+    z-index: 5;
+}

--- a/frontend/src/css/MapPage.module.css
+++ b/frontend/src/css/MapPage.module.css
@@ -1,0 +1,29 @@
+.marker {
+    background-color: var(--teal-accent);
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 100%;
+    outline: var(--teal-accent) 0.2rem solid;
+    outline-offset: 0.2rem;
+}
+
+.profilePopup {
+    display: none;
+    transform: translate(15%, -100%);
+    width: 16rem;
+    height: 16rem;
+    background-color: var(--tan-background);
+    border-radius: 2rem;
+    padding: 1rem 2rem;
+    box-sizing: border-box;
+    font-family: Sen, sans-serif;
+}
+
+.profileTitle {
+    font-family: inherit;
+    font-size: 24px;
+}
+
+.marker:hover .profilePopup {
+    display: block;
+}

--- a/frontend/src/css/MapPage.module.css
+++ b/frontend/src/css/MapPage.module.css
@@ -1,29 +1,4 @@
-.marker {
-    background-color: var(--teal-accent);
-    width: 1.5rem;
-    height: 1.5rem;
-    border-radius: 100%;
-    outline: var(--teal-accent) 0.2rem solid;
-    outline-offset: 0.2rem;
-}
-
-.profilePopup {
-    display: none;
-    transform: translate(15%, -100%);
-    width: 16rem;
-    height: 16rem;
-    background-color: var(--tan-background);
-    border-radius: 2rem;
-    padding: 1rem 2rem;
-    box-sizing: border-box;
-    font-family: Sen, sans-serif;
-}
-
-.profileTitle {
-    font-family: inherit;
-    font-size: 24px;
-}
-
-.marker:hover .profilePopup {
-    display: block;
+.map {
+    width: 100vw;
+    height: 100vh;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import SignupForm from "./components/SignupForm";
 import Dashboard from "./components/Dashboard";
 import UserProvider from "./contexts/UserContext";
 import EditProfile from "./components/EditProfile";
+import MapPage from "./components/MapPage";
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>
@@ -25,6 +26,9 @@ createRoot(document.getElementById("root")!).render(
                     <Route
                         path="/editprofile"
                         element={<EditProfile></EditProfile>}></Route>
+                    <Route
+                        path="/map"
+                        element={<MapPage></MapPage>}></Route>
                 </Routes>
             </BrowserRouter>
         </UserProvider>

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -113,17 +113,14 @@ export const updateLocation = async (
     id: number,
     data: google.maps.LatLngLiteral,
 ) => {
-    await fetch(`${import.meta.env.VITE_SERVER_URL}/user/${id}`, {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/user/location/${id}`, {
         method: "post",
         mode: "cors",
         headers: {
             "Content-Type": "application/json",
         },
         credentials: "include",
-        body: JSON.stringify({
-            latitude: data.lat,
-            longitude: data.lng,
-        }),
+        body: JSON.stringify(data),
     });
 };
 

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -124,6 +124,17 @@ export const updateLocation = async (
     });
 };
 
+/**
+ *
+ * @param id id of the user who is leaving the map page or hiding their location
+ */
+export const deleteLocation = async (id: number) => {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/user/location/${id}`, {
+        method: "delete",
+        credentials: "include",
+    });
+};
+
 const interests = [
     "Reading",
     "Cooking",

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -104,6 +104,29 @@ export const updateProfile = async (id: number, data: UserProfile) => {
     return json as UserProfile;
 };
 
+/**
+ *
+ * @param id id of the user whose location to update
+ * @param data lat and long of the user
+ */
+export const updateLocation = async (
+    id: number,
+    data: google.maps.LatLngLiteral,
+) => {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/user/${id}`, {
+        method: "post",
+        mode: "cors",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({
+            latitude: data.lat,
+            longitude: data.lng,
+        }),
+    });
+};
+
 const interests = [
     "Reading",
     "Cooking",
@@ -113,6 +136,11 @@ const interests = [
     "Hiking",
 ];
 
+/**
+ *
+ * @param id index of the interest to retrieve
+ * @returns string name of the specified interest
+ */
 export const getInterestName = (id: number) => {
     return interests[id];
 };


### PR DESCRIPTION
## Description
- Integrate with React Google Maps API to show a map centered at the user's location on MapPage
- Create MapMarker that includes a popup with user profile information on hover
- Create table UserLocation to store the locations of users active on the map page (and remove lat/long from User table)

## Milestones
- User story: can view own location/profile 
- Closes #6 

## Resources
- [MDN on getting browser location](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API)
- [Showing a map with React Google Maps](https://developers.google.com/codelabs/maps-platform/maps-platform-101-react-js#1)
- [react-google-maps component reference](https://visgl.github.io/react-google-maps/docs/api-reference/components/map)

## Test Plan
<img width="1511" alt="Screenshot 2025-06-25 at 11 50 27 AM" src="https://github.com/user-attachments/assets/2211eb8e-d648-4269-af6c-e16d61fa0a24" />
- Tested that user location is added to the database (appears in Prisma Studio) when page is loaded, and is deleted when the user clicks Back to Dashboard
