### PR TITLE
Implement geohashing for location storage

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -224,6 +224,61 @@ app.post("/user", authenticate, async (req, res) => {
     }
 });
 
+// GEOHASHING METHOD
+
+// update the logged-in user's location
+app.post("/user/geolocation", authenticate, async (req, res) => {
+    const userId = req.session.userId;
+
+    await prisma.userGeohashes.upsert({
+        create: {
+            userId: userId,
+            geohash: req.body.geohash,
+        },
+        update: {
+            geohash: req.body.geohash,
+        },
+        where: {
+            userId: userId,
+        },
+    });
+
+    res.send("Location updated");
+});
+
+// remove the logged-in user's location data from the database
+app.delete("/user/geolocation", authenticate, async (req, res) => {
+    const userId = req.session.userId;
+    try {
+        await prisma.userGeohashes.delete({
+            where: {
+                userId: userId,
+            },
+        });
+
+        res.send("Successfully deleted");
+    } catch (error) {
+        res.status(404).send("Geohash record not found");
+    }
+});
+
+// gets ids and locations of active users other than the logged-in user
+app.get("/users/otherGeolocations", authenticate, async (req, res) => {
+    const userId = req.session.userId;
+
+    const locations = await prisma.userGeohashes.findMany({
+        where: {
+            NOT: {
+                userId: userId,
+            },
+        },
+    });
+
+    res.json(locations);
+});
+
+// LAT/LONG METHOD
+
 // update the logged-in user's location
 app.post("/user/location", authenticate, async (req, res) => {
     const userId = req.session.userId;

--- a/backend/index.js
+++ b/backend/index.js
@@ -224,8 +224,6 @@ app.post("/user", authenticate, async (req, res) => {
     }
 });
 
-// GEOHASHING METHOD
-
 // update the logged-in user's location
 app.post("/user/geolocation", authenticate, async (req, res) => {
     const userId = req.session.userId;
@@ -267,61 +265,6 @@ app.get("/users/otherGeolocations", authenticate, async (req, res) => {
     const userId = req.session.userId;
 
     const locations = await prisma.userGeohashes.findMany({
-        where: {
-            NOT: {
-                userId: userId,
-            },
-        },
-    });
-
-    res.json(locations);
-});
-
-// LAT/LONG METHOD
-
-// update the logged-in user's location
-app.post("/user/location", authenticate, async (req, res) => {
-    const userId = req.session.userId;
-
-    await prisma.userLocation.upsert({
-        create: {
-            userId: userId,
-            latitude: req.body.lat,
-            longitude: req.body.lng,
-        },
-        update: {
-            latitude: req.body.lat,
-            longitude: req.body.lng,
-        },
-        where: {
-            userId: userId,
-        },
-    });
-
-    res.send("Successfully updated");
-});
-
-// remove the logged-in user's location data from the database
-app.delete("/user/location", authenticate, async (req, res) => {
-    const userId = req.session.userId;
-    try {
-        await prisma.userLocation.delete({
-            where: {
-                userId: userId,
-            },
-        });
-
-        res.send("Successfully deleted");
-    } catch (error) {
-        res.status(404).send("User location not found");
-    }
-});
-
-// gets ids and locations of active users other than the logged-in user
-app.get("/users/otherLocations", authenticate, async (req, res) => {
-    const userId = req.session.userId;
-
-    const locations = await prisma.userLocation.findMany({
         where: {
             NOT: {
                 userId: userId,

--- a/backend/prisma/migrations/20250626201624_init_geohash_table/migration.sql
+++ b/backend/prisma/migrations/20250626201624_init_geohash_table/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "UserGeohashes" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "geohash" TEXT NOT NULL,
+
+    CONSTRAINT "UserGeohashes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserGeohashes_userId_key" ON "UserGeohashes"("userId");

--- a/backend/prisma/migrations/20250626222514_drop_location_table/migration.sql
+++ b/backend/prisma/migrations/20250626222514_drop_location_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the `UserLocation` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "UserLocation";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -29,13 +29,6 @@ model User {
   friends Int[]
 }
 
-model UserLocation {
-  id Int @id @default(autoincrement())
-  userId Int @unique
-  latitude Decimal
-  longitude Decimal
-}
-
 model UserGeohashes {
   id Int @id @default(autoincrement())
   userId Int @unique

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -35,3 +35,9 @@ model UserLocation {
   latitude Decimal
   longitude Decimal
 }
+
+model UserGeohashes {
+  id Int @id @default(autoincrement())
+  userId Int @unique
+  geohash String
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
                 "@fortawesome/react-fontawesome": "^0.2.2",
                 "@vis.gl/react-google-maps": "^1.5.3",
+                "geohashing": "^2.0.1",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",
                 "react-router-dom": "^7.6.2"
@@ -2460,6 +2461,12 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/geohashing": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/geohashing/-/geohashing-2.0.1.tgz",
+            "integrity": "sha512-u0H29yhqHEyBBgwv1GJrvqbD33AnQm2lbWOLNbXLZEWVrCKNoblyiWWnVGeYGaM4NNM7rBBTqvJZhZ/CDfrBVw==",
+            "license": "MIT"
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@vis.gl/react-google-maps": "^1.5.3",
+        "geohashing": "^2.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2"

--- a/frontend/src/components/MapMarker.tsx
+++ b/frontend/src/components/MapMarker.tsx
@@ -4,11 +4,11 @@ import { useState, useEffect } from "react";
 import type { UserProfile } from "../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
-import { getInterestName, getProfile } from "../utils";
+import { geoHashToLatLng, getInterestName, getProfile } from "../utils";
 
 interface MapMarkerProps {
     id: number;
-    location: google.maps.LatLngLiteral;
+    location: string;
 }
 
 /**
@@ -35,7 +35,7 @@ const MapMarker = ({ id, location }: MapMarkerProps) => {
     }, []);
 
     return (
-        <AdvancedMarker position={location}>
+        <AdvancedMarker position={geoHashToLatLng(location)}>
             <div className={styles.marker}>
                 <FontAwesomeIcon
                     className={styles.markerIcon}

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -7,7 +7,7 @@ import {
     deleteGeohash,
     geoHashToLatLng,
     getOtherUserGeohashes,
-    isGeoHashWithin3Mi,
+    isGeoHashWithinMi,
     updateGeohash,
 } from "../utils";
 import MapMarker from "./MapMarker";
@@ -37,6 +37,9 @@ const MapPage = () => {
 
     // whether or not user's location is hidden from others
     const [hideLocation, setHideLocation] = useState(false);
+
+    // radius in which to show other users
+    const [radius, setRadius] = useState<0.5 | 3 | 20>(0.5);
 
     // when Back button is clicked, remove user's location from active table and navigate to dashboard
     const handleBack = () => {
@@ -107,7 +110,7 @@ const MapPage = () => {
                     <FontAwesomeIcon icon={faArrowLeftLong}></FontAwesomeIcon>{" "}
                     Back to Dashboard
                 </button>
-                <div className={styles.sliderSection}>
+                <div className={styles.hideLocationContainer}>
                     <div className={styles.sliderLabel}>
                         <h6 className={styles.sliderTitle}>Hide location?</h6>
                         <p className={styles.sliderLabelText}>
@@ -121,6 +124,22 @@ const MapPage = () => {
                             setValue={setHideLocation}
                             options={[false, true]}
                             optionsDisplay={["Show", "Hide"]}></Slider>
+                    </div>
+                </div>
+                <div className={styles.radiusContainer}>
+                    <div className={styles.sliderContainer}>
+                        <Slider
+                            value={radius}
+                            setValue={setRadius}
+                            options={[0.5, 3, 20]}
+                            optionsDisplay={["0.5mi", "3mi", "20mi"]}></Slider>
+                    </div>
+                    <div className={styles.sliderLabel}>
+                        <h6 className={styles.sliderTitle}>Nearby radius</h6>
+                        <p className={styles.sliderLabelText}>
+                            Choose a radius around you in which to show other
+                            users.
+                        </p>
                     </div>
                 </div>
 
@@ -137,10 +156,10 @@ const MapPage = () => {
 
                     {otherUsers
                         .filter((userLoc) => {
-                            // only show users within a 3mi circle
-                            return isGeoHashWithin3Mi(
+                            return isGeoHashWithinMi(
                                 myLocation,
                                 userLoc.geohash,
+                                radius,
                             );
                         })
                         .map((user) => {

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -1,20 +1,23 @@
 import styles from "../css/MapPage.module.css";
 import { useUser } from "../contexts/UserContext";
 import { useState, useEffect } from "react";
-import { Map, useMapsLibrary } from "@vis.gl/react-google-maps";
+import { Map } from "@vis.gl/react-google-maps";
 import LoggedOut from "./LoggedOut";
 import {
-    deleteLocation,
-    getOtherUserLocations,
-    updateLocation,
+    deleteGeohash,
+    geoHashToLatLng,
+    getOtherUserGeohashes,
+    isGeoHashWithin3Mi,
+    updateGeohash,
 } from "../utils";
 import MapMarker from "./MapMarker";
-import { DEFAULT_MAP_ZOOM, FETCH_INTERVAL, NEARBY_RADIUS } from "../constants";
+import { DEFAULT_MAP_ZOOM, FETCH_INTERVAL } from "../constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeftLong } from "@fortawesome/free-solid-svg-icons";
 import { useBeforeUnload, useNavigate } from "react-router-dom";
-import type { UserLocation } from "../types";
+import type { UserGeohash } from "../types";
 import Slider from "./Slider";
+import { encodeBase32 } from "geohashing";
 
 /**
  *
@@ -27,11 +30,10 @@ const MapPage = () => {
     const { user } = useUser();
 
     // array of other users
-    const [otherUsers, setOtherUsers] = useState(Array() as UserLocation[]);
+    const [otherUsers, setOtherUsers] = useState(Array() as UserGeohash[]);
 
     // location of the current user
-    const [myLocation, setMyLocation] =
-        useState<google.maps.LatLngLiteral | null>(null);
+    const [myLocation, setMyLocation] = useState<string | null>(null);
 
     // whether or not user's location is hidden from others
     const [hideLocation, setHideLocation] = useState(false);
@@ -39,7 +41,7 @@ const MapPage = () => {
     // when Back button is clicked, remove user's location from active table and navigate to dashboard
     const handleBack = () => {
         if (user) {
-            deleteLocation();
+            deleteGeohash();
         }
 
         navigate("/");
@@ -48,7 +50,7 @@ const MapPage = () => {
     // before window unloads, remove user's location from active table (handles navigation not using Back button)
     useBeforeUnload((_) => {
         if (user) {
-            deleteLocation();
+            deleteGeohash();
         }
     });
 
@@ -57,43 +59,30 @@ const MapPage = () => {
         // get browser location
         const geo = navigator.geolocation;
         geo.getCurrentPosition((position) => {
+            const geohash = encodeBase32(
+                position.coords.latitude,
+                position.coords.longitude,
+            );
+
             // on success, set location state variable
-            setMyLocation({
-                lat: position.coords.latitude,
-                lng: position.coords.longitude,
-            });
+            setMyLocation(geohash);
 
             if (user) {
                 if (hideLocation) {
                     // delete location from database so no other users can see it
-                    deleteLocation();
+                    deleteGeohash();
                 } else {
                     // update location in database
-                    updateLocation({
-                        lat: position.coords.latitude,
-                        lng: position.coords.longitude,
-                    });
+                    updateGeohash(geohash);
                 }
 
                 // get locations of all other users online
-                getOtherUserLocations().then((users) => {
-                    setOtherUsers(
-                        users.map((user: UserLocation) => {
-                            return {
-                                id: user.id,
-                                userId: user.userId,
-                                latitude: Number(user.latitude),
-                                longitude: Number(user.longitude),
-                            };
-                        }),
-                    );
+                getOtherUserGeohashes().then((users) => {
+                    setOtherUsers(users);
                 });
             }
         });
     };
-
-    // library for spherical geometry functions such as distance
-    const geometry = useMapsLibrary("geometry");
 
     // at each interval, reload location data
     useEffect(() => {
@@ -109,7 +98,7 @@ const MapPage = () => {
 
     if (!user) {
         return <LoggedOut></LoggedOut>;
-    } else if (myLocation && geometry) {
+    } else if (myLocation) {
         return (
             <>
                 <button
@@ -137,7 +126,7 @@ const MapPage = () => {
 
                 <Map
                     className={styles.map}
-                    defaultCenter={myLocation}
+                    defaultCenter={geoHashToLatLng(myLocation)}
                     mapId={"Users Map"}
                     defaultZoom={DEFAULT_MAP_ZOOM}
                     gestureHandling={"greedy"}
@@ -148,25 +137,17 @@ const MapPage = () => {
 
                     {otherUsers
                         .filter((userLoc) => {
-                            // only show users within a circle of NEARBY_RADIUS
-                            return (
-                                geometry.spherical.computeDistanceBetween(
-                                    myLocation,
-                                    {
-                                        lat: userLoc.latitude,
-                                        lng: userLoc.longitude,
-                                    },
-                                ) < NEARBY_RADIUS
+                            // only show users within a 3mi circle
+                            return isGeoHashWithin3Mi(
+                                myLocation,
+                                userLoc.geohash,
                             );
                         })
                         .map((user) => {
                             return (
                                 <MapMarker
                                     id={user.userId}
-                                    location={{
-                                        lat: user.latitude,
-                                        lng: user.longitude,
-                                    }}></MapMarker>
+                                    location={user.geohash}></MapMarker>
                             );
                         })}
                 </Map>

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -11,7 +11,7 @@ import {
     updateGeohash,
 } from "../utils";
 import MapMarker from "./MapMarker";
-import { DEFAULT_MAP_ZOOM, FETCH_INTERVAL } from "../constants";
+import { DEFAULT_MAP_ZOOM, FETCH_INTERVAL, GEOHASH_RADII } from "../constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeftLong } from "@fortawesome/free-solid-svg-icons";
 import { useBeforeUnload, useNavigate } from "react-router-dom";
@@ -39,7 +39,7 @@ const MapPage = () => {
     const [hideLocation, setHideLocation] = useState(false);
 
     // radius in which to show other users
-    const [radius, setRadius] = useState<0.5 | 3 | 20>(0.5);
+    const [radius, setRadius] = useState(GEOHASH_RADII[0].radius);
 
     // when Back button is clicked, remove user's location from active table and navigate to dashboard
     const handleBack = () => {
@@ -131,8 +131,12 @@ const MapPage = () => {
                         <Slider
                             value={radius}
                             setValue={setRadius}
-                            options={[0.5, 3, 20]}
-                            optionsDisplay={["0.5mi", "3mi", "20mi"]}></Slider>
+                            options={GEOHASH_RADII.map(
+                                (element) => element.radius,
+                            )}
+                            optionsDisplay={GEOHASH_RADII.map(
+                                (element) => element.radius + "mi",
+                            )}></Slider>
                     </div>
                     <div className={styles.sliderLabel}>
                         <h6 className={styles.sliderTitle}>Nearby radius</h6>

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -10,6 +10,24 @@ export const DEFAULT_MAP_ZOOM = 16;
 export const NEARBY_RADIUS = 1000;
 
 /**
+ * If two geohashes' first 4 characters are not identical,
+ * we can rule them out of being within 20 miles of each other (at 30deg lat) [ref](https://bhaugen.com/blog/geohash-sizes/)
+ */
+export const GEOHASH_20MI_RES = 4;
+
+/**
+ * If two geohashes' first 5 characters are not identical,
+ * we can rule them out of being within 3 miles of each other (at 30deg lat) [ref](https://bhaugen.com/blog/geohash-sizes/)
+ */
+export const GEOHASH_3MI_RES = 5;
+
+/**
+ * If two geohashes' first 6 characters are not identical,
+ * we can rule them out of being within 0.5 miles of each other (at 30deg lat) [ref](https://bhaugen.com/blog/geohash-sizes/)
+ */
+export const GEOHASH_HALFMI_RES = 6;
+
+/**
  * Interval in milliseconds at which user's browser location is updated and other users' locations are re-fetched
  */
 export const FETCH_INTERVAL = 5000;

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -4,28 +4,23 @@
 export const DEFAULT_MAP_ZOOM = 16;
 
 /**
- * Radius in meters of the circle in which other users are shown to the user.
- * This will eventually be customizable on the user's end, but for now it is a constant here
+ * Array of objects representing known radii in miles and their corresponding geohash resolution:
+ * if two geohashes are identical up to res characters, they must be within radius miles of each other, assuming ~30deg lat
  */
-export const NEARBY_RADIUS = 1000;
-
-/**
- * If two geohashes' first 4 characters are not identical,
- * we can rule them out of being within 20 miles of each other (at 30deg lat) [ref](https://bhaugen.com/blog/geohash-sizes/)
- */
-export const GEOHASH_20MI_RES = 4;
-
-/**
- * If two geohashes' first 5 characters are not identical,
- * we can rule them out of being within 3 miles of each other (at 30deg lat) [ref](https://bhaugen.com/blog/geohash-sizes/)
- */
-export const GEOHASH_3MI_RES = 5;
-
-/**
- * If two geohashes' first 6 characters are not identical,
- * we can rule them out of being within 0.5 miles of each other (at 30deg lat) [ref](https://bhaugen.com/blog/geohash-sizes/)
- */
-export const GEOHASH_HALFMI_RES = 6;
+export const GEOHASH_RADII = [
+    {
+        radius: 0.5,
+        res: 6,
+    },
+    {
+        radius: 3,
+        res: 5,
+    },
+    {
+        radius: 20,
+        res: 4,
+    },
+];
 
 /**
  * Interval in milliseconds at which user's browser location is updated and other users' locations are re-fetched

--- a/frontend/src/css/MapPage.module.css
+++ b/frontend/src/css/MapPage.module.css
@@ -16,7 +16,7 @@
     z-index: 5;
 }
 
-.sliderSection {
+.hideLocationContainer {
     z-index: 5;
     position: fixed;
     right: 0;
@@ -27,6 +27,20 @@
     align-items: center;
     gap: 1rem;
     width: 15rem;
+}
+
+.radiusContainer {
+    z-index: 5;
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    margin: 1rem;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    width: 25rem;
 }
 
 .sliderContainer {

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -33,3 +33,9 @@ export interface UserLocation {
     latitude: number;
     longitude: number;
 }
+
+export interface UserGeohash {
+    id: number;
+    userId: number;
+    geohash: string;
+}

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,5 +1,6 @@
 import { decodeBase32 } from "geohashing";
 import type { UserProfile } from "./types";
+import { GEOHASH_3MI_RES } from "./constants";
 
 /**
  *
@@ -125,6 +126,10 @@ export const getInterestName = (id: number) => {
 
 // GEOHASHING METHOD
 
+/**
+ *
+ * @param hash the geohash of the logged-in user's new location
+ */
 export const updateGeohash = async (hash: string) => {
     await fetch(`${import.meta.env.VITE_SERVER_URL}/user/geolocation`, {
         method: "post",
@@ -139,6 +144,10 @@ export const updateGeohash = async (hash: string) => {
     });
 };
 
+/**
+ *
+ * @returns true if logged-in user's hash record was found and deleted, false otherwise
+ */
 export const deleteGeohash = async () => {
     const response = await fetch(
         `${import.meta.env.VITE_SERVER_URL}/user/geolocation`,
@@ -151,6 +160,10 @@ export const deleteGeohash = async () => {
     return response.ok;
 };
 
+/**
+ *
+ * @returns UserGeohash array representing locations of all active users other than the logged-in user
+ */
 export const getOtherUserGeohashes = async () => {
     const response = await fetch(
         `${import.meta.env.VITE_SERVER_URL}/users/otherGeolocations`,
@@ -164,12 +177,27 @@ export const getOtherUserGeohashes = async () => {
     return otherUsers;
 };
 
+/**
+ *
+ * @param hash the base32 geohash
+ * @returns a LatLngLiteral contained within the geohash rectangle
+ */
 export const geoHashToLatLng = (hash: string) => {
     const { lat, lng } = decodeBase32(hash);
     return {
         lat: lat,
         lng: lng,
     };
+};
+
+/**
+ *
+ * @param center a geohash (the center of a 3mi circle)
+ * @param hash another geohash
+ * @returns true if hash is within at least 3mi of center (assuming 30deg lat)
+ */
+export const isGeoHashWithin3Mi = (center: string, hash: string) => {
+    return center.slice(0, GEOHASH_3MI_RES) === hash.slice(0, GEOHASH_3MI_RES);
 };
 
 // LAT/LONG METHOD

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,3 +1,4 @@
+import { decodeBase32 } from "geohashing";
 import type { UserProfile } from "./types";
 
 /**
@@ -104,6 +105,75 @@ export const updateProfile = async (data: UserProfile) => {
     return response.ok;
 };
 
+const interests = [
+    "Reading",
+    "Cooking",
+    "Drawing",
+    "Painting",
+    "Swimming",
+    "Hiking",
+];
+
+/**
+ *
+ * @param id index of the interest to retrieve
+ * @returns string name of the specified interest
+ */
+export const getInterestName = (id: number) => {
+    return interests[id];
+};
+
+// GEOHASHING METHOD
+
+export const updateGeohash = async (hash: string) => {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/user/geolocation`, {
+        method: "post",
+        mode: "cors",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({
+            geohash: hash,
+        }),
+    });
+};
+
+export const deleteGeohash = async () => {
+    const response = await fetch(
+        `${import.meta.env.VITE_SERVER_URL}/user/geolocation`,
+        {
+            method: "delete",
+            credentials: "include",
+        },
+    );
+
+    return response.ok;
+};
+
+export const getOtherUserGeohashes = async () => {
+    const response = await fetch(
+        `${import.meta.env.VITE_SERVER_URL}/users/otherGeolocations`,
+        {
+            credentials: "include",
+        },
+    );
+
+    const otherUsers = await response.json();
+
+    return otherUsers;
+};
+
+export const geoHashToLatLng = (hash: string) => {
+    const { lat, lng } = decodeBase32(hash);
+    return {
+        lat: lat,
+        lng: lng,
+    };
+};
+
+// LAT/LONG METHOD
+
 /**
  *
  * @param data lat and long of the logged-in user
@@ -135,24 +205,6 @@ export const deleteLocation = async () => {
     );
 
     return response.ok;
-};
-
-const interests = [
-    "Reading",
-    "Cooking",
-    "Drawing",
-    "Painting",
-    "Swimming",
-    "Hiking",
-];
-
-/**
- *
- * @param id index of the interest to retrieve
- * @returns string name of the specified interest
- */
-export const getInterestName = (id: number) => {
-    return interests[id];
 };
 
 /**

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,6 +1,10 @@
 import { decodeBase32 } from "geohashing";
 import type { UserProfile } from "./types";
-import { GEOHASH_3MI_RES } from "./constants";
+import {
+    GEOHASH_20MI_RES,
+    GEOHASH_3MI_RES,
+    GEOHASH_HALFMI_RES,
+} from "./constants";
 
 /**
  *
@@ -192,12 +196,24 @@ export const geoHashToLatLng = (hash: string) => {
 
 /**
  *
- * @param center a geohash (the center of a 3mi circle)
+ * @param center a geohash (the center of a circle of radius miles)
  * @param hash another geohash
- * @returns true if hash is within at least 3mi of center (assuming 30deg lat)
+ * @param radius either 0.5, 3, or 20 (these values correspond to certain hash length precision)
+ * @returns true if hash is within at least radius of center (assuming 30deg lat)
  */
-export const isGeoHashWithin3Mi = (center: string, hash: string) => {
-    return center.slice(0, GEOHASH_3MI_RES) === hash.slice(0, GEOHASH_3MI_RES);
+export const isGeoHashWithinMi = (
+    center: string,
+    hash: string,
+    radius: 0.5 | 3 | 20,
+) => {
+    const res =
+        radius === 0.5
+            ? GEOHASH_HALFMI_RES
+            : radius === 3
+              ? GEOHASH_3MI_RES
+              : GEOHASH_20MI_RES;
+
+    return center.slice(0, res) === hash.slice(0, res);
 };
 
 // LAT/LONG METHOD


### PR DESCRIPTION
## Description
- Create UserGeohashes table and drop UserLocation table in database
- Rework backend routes and utils functions to store user geohashes to new table instead of lat/long coordinates
- Add slider to MapPage to allow user to choose query radius for other user locations
### Future work
- The slider options are rough estimates of the maximum distance between two geohashes with identical prefixes of a certain length, as outlined in constants.tsx. To provide more options and accuracy, prefix comparison could instead be used in a first pass to rule out users who are definitely too far away; then lat/long could be used to determine whether a user is truly within the circle.

## Milestones
- Improves efficiency of calculating nearby user positions on MapPage
- Slider improves MapPage customizability and UX

## Resources
[geohashing library](https://github.com/arseny034/geohashing?tab=readme-ov-file)
[Tables of max distances between geohashes](https://bhaugen.com/blog/geohash-sizes/)
- I got the 0.5, 3, and 20mi cutoffs from the length in miles of the smaller side of the rectangle for resolutions 4, 5, and 6 in the 30deg table (we are at ~37deg latitude).

## Test Plan

https://github.com/user-attachments/assets/fd057671-7345-40e6-87e0-56342b30c563

- In the video, the other users are approximately 2.8 and 12mi away. So, the table distances seem to be working, but in future as described above I plan to actually check lat/long for distance if a user makes it past the geohashing check.
- Retested location hiding, leaving page, and other MapPage actions with new utils functions
