### PR TITLE
Improve place recommendation algorithm

### DIFF
--- a/backend/constants.js
+++ b/backend/constants.js
@@ -12,3 +12,8 @@ export const MAX_LOGIN_ATTEMPTS = 5;
  * Session cookie expiration time in ms
  */
 export const SESSION_TIMEOUT = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * If two geohashes are identical up to this number of characters, we only need 1 recorded in the past locations table
+ */
+export const GEOHASH_DUP_RES = 8;

--- a/backend/index.js
+++ b/backend/index.js
@@ -295,3 +295,23 @@ app.get("/users/otherGeolocations", authenticate, async (req, res) => {
 
     res.json(locations);
 });
+
+app.post("/user/geolocation/history", authenticate, async (req, res) => {
+    const userId = req.session.userId;
+
+    const hash = req.body.geohash;
+
+    if (!hash) {
+        return res.status(400).send("Geohash is required");
+    }
+
+    await prisma.userPastGeohashes.create({
+        data: {
+            userId: userId,
+            timestamp: new Date(),
+            geohash: hash,
+        },
+    });
+
+    res.send("Successfully recorded");
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -296,6 +296,7 @@ app.get("/users/otherGeolocations", authenticate, async (req, res) => {
     res.json(locations);
 });
 
+// add a new record to user's past locations
 app.post("/user/geolocation/history", authenticate, async (req, res) => {
     const userId = req.session.userId;
 
@@ -314,4 +315,17 @@ app.post("/user/geolocation/history", authenticate, async (req, res) => {
     });
 
     res.send("Successfully recorded");
+});
+
+// get all of user's past locations
+app.get("/user/geolocation/history", authenticate, async (req, res) => {
+    const userId = req.session.userId;
+
+    const history = await prisma.userPastGeohashes.findMany({
+        where: {
+            userId: userId,
+        },
+    });
+
+    res.json(history);
 });

--- a/backend/prisma/migrations/20250630161648_init_past_locations_table/migration.sql
+++ b/backend/prisma/migrations/20250630161648_init_past_locations_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "UserPastGeohashes" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL,
+    "geohash" TEXT NOT NULL,
+
+    CONSTRAINT "UserPastGeohashes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserPastGeohashes_userId_key" ON "UserPastGeohashes"("userId");

--- a/backend/prisma/migrations/20250630164743_drop_unique_userid/migration.sql
+++ b/backend/prisma/migrations/20250630164743_drop_unique_userid/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "UserPastGeohashes_userId_key";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -34,3 +34,10 @@ model UserGeohashes {
   userId Int @unique
   geohash String
 }
+
+model UserPastGeohashes {
+  id Int @id @default(autoincrement())
+  userId Int
+  timestamp DateTime
+  geohash String
+}

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -80,6 +80,9 @@ const MapPage = () => {
 
             // set location state variable
             setMyLocation((oldLocation) => {
+                // compare old and new locations for tracking time spent; if this is not done
+                // within setState, we might get stale values of oldLocation/myLocation when this function
+                // is called in the setInterval
                 if (oldLocation) {
                     if (!areHashesClose(geohash, oldLocation)) {
                         // if the user has moved, reset tracked time

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -8,7 +8,7 @@ import {
     deleteGeohash,
     geoHashToLatLng,
     getOtherUserGeohashes,
-    hasUserMoved,
+    areHashesClose,
     isGeoHashWithinMi,
     updateGeohash,
 } from "../utils";
@@ -81,7 +81,7 @@ const MapPage = () => {
             // set location state variable
             setMyLocation((oldLocation) => {
                 if (oldLocation) {
-                    if (hasUserMoved(geohash, oldLocation)) {
+                    if (!areHashesClose(geohash, oldLocation)) {
                         // if they have moved, reset tracked time
                         timeAtLocation.current = 0;
                     } else if (timeAtLocation.current !== -1) {

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -1,17 +1,24 @@
 import styles from "../css/MapPage.module.css";
 import { useUser } from "../contexts/UserContext";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Map } from "@vis.gl/react-google-maps";
 import LoggedOut from "./LoggedOut";
 import {
+    addPastGeohash,
     deleteGeohash,
     geoHashToLatLng,
     getOtherUserGeohashes,
+    hasUserMoved,
     isGeoHashWithinMi,
     updateGeohash,
 } from "../utils";
 import MapMarker from "./MapMarker";
-import { DEFAULT_MAP_ZOOM, FETCH_INTERVAL, GEOHASH_RADII } from "../constants";
+import {
+    DEFAULT_MAP_ZOOM,
+    FETCH_INTERVAL,
+    GEOHASH_RADII,
+    SIG_TIME_AT_LOCATION,
+} from "../constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeftLong } from "@fortawesome/free-solid-svg-icons";
 import { useBeforeUnload, useNavigate } from "react-router-dom";
@@ -42,6 +49,9 @@ const MapPage = () => {
     // radius in which to show other users
     const [radius, setRadius] = useState(GEOHASH_RADII[0].radius);
 
+    // seconds spent at approximately this location
+    const timeAtLocation = useRef(0);
+
     // when Back button is clicked, remove user's location from active table and navigate to dashboard
     const handleBack = () => {
         if (user) {
@@ -68,8 +78,28 @@ const MapPage = () => {
                 position.coords.longitude,
             );
 
-            // on success, set location state variable
-            setMyLocation(geohash);
+            // set location state variable
+            setMyLocation((oldLocation) => {
+                if (oldLocation) {
+                    if (hasUserMoved(geohash, oldLocation)) {
+                        // if they have moved, reset tracked time
+                        timeAtLocation.current = 0;
+                    } else if (timeAtLocation.current !== -1) {
+                        // otherwise, increase time by interval seconds
+                        timeAtLocation.current += FETCH_INTERVAL / 1000;
+
+                        // if this has reached a significant amount of time, record in database
+                        if (timeAtLocation.current >= SIG_TIME_AT_LOCATION) {
+                            addPastGeohash(geohash);
+
+                            // prevent this location from being added again until the user moves
+                            timeAtLocation.current = -1;
+                        }
+                    }
+                }
+
+                return geohash;
+            });
 
             if (user) {
                 if (hideLocation) {

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -82,7 +82,7 @@ const MapPage = () => {
             setMyLocation((oldLocation) => {
                 if (oldLocation) {
                     if (!areHashesClose(geohash, oldLocation)) {
-                        // if they have moved, reset tracked time
+                        // if the user has moved, reset tracked time
                         timeAtLocation.current = 0;
                     } else if (timeAtLocation.current !== -1) {
                         // otherwise, increase time by interval seconds

--- a/frontend/src/components/RecommendationList.tsx
+++ b/frontend/src/components/RecommendationList.tsx
@@ -60,12 +60,14 @@ const RecommendationList = ({
                         <p className={styles.placeAddress}>
                             {place.place.formattedAddress}
                         </p>
+                        <p className={styles.placeAddress}>{place.geohash}</p>
                         <p className={styles.userList}>
                             {place.userData.count}{" "}
                             {place.userData.count === 1
                                 ? "user is"
                                 : "users are"}{" "}
-                            here.
+                            here. You've been here {place.numVisits}{" "}
+                            {place.numVisits === 1 ? "time" : "times"} before.
                         </p>
                     </div>
                 ))}

--- a/frontend/src/components/RecommendationList.tsx
+++ b/frontend/src/components/RecommendationList.tsx
@@ -60,7 +60,6 @@ const RecommendationList = ({
                         <p className={styles.placeAddress}>
                             {place.place.formattedAddress}
                         </p>
-                        <p className={styles.placeAddress}>{place.geohash}</p>
                         <p className={styles.userList}>
                             {place.userData.count}{" "}
                             {place.userData.count === 1

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -34,6 +34,11 @@ export const GEOHASH_AT_PLACE_RES = 8;
 export const FETCH_INTERVAL = 5000;
 
 /**
+ * Number of seconds for a user to remain in the same place considered significant enough to record in database
+ */
+export const SIG_TIME_AT_LOCATION = 60;
+
+/**
  * Time in ms when an alert is animating and on the screen
  */
 export const ALERT_DURATION = 3000;

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -76,4 +76,9 @@ export const FRIEND_COUNT_WEIGHT = 4;
 /**
  * Weight of distance in place recommendation algorithm
  */
-export const DISTANCE_WEIGHT = 2.5;
+export const DISTANCE_WEIGHT = 1;
+
+/**
+ * Weight of number of past visits to the place in place recommendation algorithm
+ */
+export const PAST_WEIGHT = 5;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
@@ -11,34 +10,30 @@ import MapPage from "./components/MapPage";
 import { APIProvider } from "@vis.gl/react-google-maps";
 
 createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-        <UserProvider>
-            <BrowserRouter>
-                <Routes>
-                    <Route
-                        path="/"
-                        element={<Dashboard></Dashboard>}></Route>
-                    <Route
-                        path="/signup"
-                        element={<SignupForm></SignupForm>}></Route>
-                    <Route
-                        path="/login"
-                        element={<LoginForm></LoginForm>}></Route>
-                    <Route
-                        path="/editprofile"
-                        element={<EditProfile></EditProfile>}></Route>
-                    <Route
-                        path="/map"
-                        element={
-                            <APIProvider
-                                apiKey={
-                                    import.meta.env.VITE_GOOGLE_MAPS_API_KEY
-                                }>
-                                <MapPage></MapPage>
-                            </APIProvider>
-                        }></Route>
-                </Routes>
-            </BrowserRouter>
-        </UserProvider>
-    </StrictMode>,
+    <UserProvider>
+        <BrowserRouter>
+            <Routes>
+                <Route
+                    path="/"
+                    element={<Dashboard></Dashboard>}></Route>
+                <Route
+                    path="/signup"
+                    element={<SignupForm></SignupForm>}></Route>
+                <Route
+                    path="/login"
+                    element={<LoginForm></LoginForm>}></Route>
+                <Route
+                    path="/editprofile"
+                    element={<EditProfile></EditProfile>}></Route>
+                <Route
+                    path="/map"
+                    element={
+                        <APIProvider
+                            apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}>
+                            <MapPage></MapPage>
+                        </APIProvider>
+                    }></Route>
+            </Routes>
+        </BrowserRouter>
+    </UserProvider>,
 );

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -77,7 +77,14 @@ export interface PlaceRecData {
     numVisits: number;
     userData: {
         count: number;
-        averageSimilarity: number;
+        avgInterestAngle: number;
         friendCount: number;
     };
+}
+
+export interface PlaceRecUserData {
+    id: number;
+    geohash: string;
+    friend: boolean;
+    interestAngle: number;
 }

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -52,6 +52,13 @@ export interface Place {
     };
 }
 
+export interface PlaceHistory {
+    id: number;
+    userId: number;
+    timestamp: Date;
+    geohash: string;
+}
+
 /**
  * Represents data on a place and the users at that place in relation to the current user
  *
@@ -67,6 +74,7 @@ export interface PlaceRecData {
     place: Place;
     geohash: string;
     geohashDistance: number;
+    numVisits: number;
     userData: {
         count: number;
         users: {

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -77,11 +77,7 @@ export interface PlaceRecData {
     numVisits: number;
     userData: {
         count: number;
-        users: {
-            id: number;
-            geohash: string;
-            friend: boolean;
-            interestSimilarity: number;
-        }[];
+        averageSimilarity: number;
+        friendCount: number;
     };
 }

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -246,6 +246,37 @@ export const isUserAtPlace = (
 };
 
 /**
+ *
+ * @param currentHash the geohash of the user's most recently updated location
+ * @param oldHash the geohash of the user's previous location
+ * @returns true if the user has significantly moved from oldHash; false if not
+ */
+export const hasUserMoved = (currentHash: string, oldHash: string) => {
+    return (
+        currentHash.slice(0, GEOHASH_AT_PLACE_RES) !==
+        oldHash.slice(0, GEOHASH_AT_PLACE_RES)
+    );
+};
+
+/**
+ *
+ * @param hash the geohash of the location where the user stayed for a significant amount of time
+ */
+export const addPastGeohash = async (hash: string) => {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/user/geolocation/history`, {
+        method: "post",
+        mode: "cors",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({
+            geohash: hash,
+        }),
+    });
+};
+
+/**
  * Perform a Google Maps Places API (New) Nearby Search for places of interest near the user
  * @param hash the geohash of the user's current location
  * @returns MAX_PLACE_RESULTS nearby points of interest

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -245,19 +245,25 @@ export const areHashesClose = (hash1: string, hash2: string) => {
 /**
  *
  * @param hash the geohash of the location where the user stayed for a significant amount of time
+ * @returns true if the hash was recorded; false if the hash is very close to an existing record and was not recorded again
  */
 export const addPastGeohash = async (hash: string) => {
-    await fetch(`${import.meta.env.VITE_SERVER_URL}/user/geolocation/history`, {
-        method: "post",
-        mode: "cors",
-        headers: {
-            "Content-Type": "application/json",
+    const response = await fetch(
+        `${import.meta.env.VITE_SERVER_URL}/user/geolocation/history`,
+        {
+            method: "post",
+            mode: "cors",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            credentials: "include",
+            body: JSON.stringify({
+                geohash: hash,
+            }),
         },
-        credentials: "include",
-        body: JSON.stringify({
-            geohash: hash,
-        }),
-    });
+    );
+
+    return response.ok;
 };
 
 /**

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -384,17 +384,13 @@ const angleBetweenInterestVectors = (v1: number[], v2: number[]) => {
  * maximum length is the length of the shorter string
  */
 const numSameCharacters = (string1: string, string2: string) => {
-    let num = 0;
+    let i = 0;
 
-    for (let i = 0; i < Math.min(string1.length, string2.length); i++) {
-        if (string1.charAt(i) === string2.charAt(i)) {
-            num++;
-        } else {
-            return num;
-        }
+    while (string1.charAt(i) === string2.charAt(i)) {
+        i++;
     }
 
-    return num;
+    return i;
 };
 
 /**

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -397,6 +397,10 @@ const numSameCharacters = (string1: string, string2: string) => {
     return num;
 };
 
+/**
+ *
+ * @returns array of objects representing current user's previous locations
+ */
 const getUserLocationHistory = async () => {
     const response = await fetch(
         `${import.meta.env.VITE_SERVER_URL}/user/geolocation/history`,


### PR DESCRIPTION
## Description
- Add UserPastGeohashes table to database and incorporate the number of times the user has been to a place before into the recommendation score for that place
- Remove StrictMode: this was causing two intervals to start on MapPage, which began to double-count all increases in timeAtLocation
- Move most recommendation score calculations into the loop over places in recommendPlaces, so that they are not performed at each comparison in sortRecommendations
- Make a place's default average interest angle pi/2 instead of 0 if it has no users; since a higher angle counts against a place in the algorithm, the default 0 was putting places with 0 users present higher in the list than they should have been
- Change/add comments and refactor in response to comments on #16 
### Future work
- The recommendation weights have been improved, but can still be tested
- Past location storage appears to work, but should be tested with multiple real users

## Milestones
- Closes #14 (though there is much room for further improvement)

## Resources
- [useEffect and state updater functions](https://react.dev/reference/react/useEffect#updating-state-based-on-previous-state-from-an-effect)
- [JS array sort comparison functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description)
- [very nice HTTP code reference](https://http.cat/)

## Test Plan

https://github.com/user-attachments/assets/6a3f62c6-19e5-4f35-bb87-82d8448e3ded

- For demonstration purposes, the weights have been adjusted so that past visits matter most, followed by number of users present and average similarity, then distance
- Past locations are being tested with dummy data in UserPastGeohashes for now
