### PR TITLE
Friending and blocking other users

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -395,10 +395,23 @@ app.post("/friend/:to", authenticate, async (req, res) => {
             },
         })) > 0;
 
-    if (duplicateExists) {
+    const userFromFriends = await prisma.user.findUnique({
+        where: {
+            id: from,
+        },
+        select: {
+            friends: true,
+        },
+    });
+
+    const alreadyFriends = userFromFriends.friends.includes(to);
+
+    if (duplicateExists || alreadyFriends) {
         return res
             .status(409)
-            .send("A friend request between these users already exists");
+            .send(
+                "A friend request or relation between these users already exists",
+            );
     }
 
     await prisma.friendRequest.create({

--- a/backend/index.js
+++ b/backend/index.js
@@ -380,6 +380,7 @@ app.post("/friend/:to", authenticate, async (req, res) => {
 
     const to = parseInt(req.params.to);
 
+    // check whether an active friend request exists between them or they are already friends
     const duplicateExists =
         (await prisma.friendRequest.count({
             where: {
@@ -425,6 +426,7 @@ app.post("/friend/:to", authenticate, async (req, res) => {
     res.status(201).send("Friend request sent");
 });
 
+// get all active friend requests to the logged-in user
 app.get("/friend", async (req, res) => {
     const userId = req.session.userId;
 
@@ -437,6 +439,7 @@ app.get("/friend", async (req, res) => {
     res.json(requests);
 });
 
+// delete the friend request from the specified user to the logged-in user and make them friends
 app.post("/friend/accept/:from", async (req, res) => {
     const to = req.session.userId;
 
@@ -482,6 +485,7 @@ app.post("/friend/accept/:from", async (req, res) => {
     res.send("Request accepted");
 });
 
+// delete the friend request from the specified user to the logged-in user
 app.post("/friend/decline/:from", async (req, res) => {
     const to = req.session.userId;
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -205,6 +205,34 @@ app.get("/user/:id", authenticate, async (req, res) => {
     res.json(user);
 });
 
+app.get("/user/details/:id", authenticate, async (req, res) => {
+    const userId = parseInt(req.params.id);
+
+    const user = await prisma.user.findUnique({
+        where: {
+            id: userId,
+        },
+        select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            pronouns: true,
+            age: true,
+            major: true,
+            interests: true,
+            bio: true,
+            friends: true,
+            interests: true,
+        },
+    });
+
+    if (!user) {
+        return res.status(404).send("User not found");
+    }
+
+    res.json(user);
+});
+
 // get a user's friends and interests
 app.get("/user/friendsAndInterests/:id", authenticate, async (req, res) => {
     const userId = parseInt(req.params.id);

--- a/backend/index.js
+++ b/backend/index.js
@@ -462,7 +462,7 @@ app.post("/friend/accept/:from", async (req, res) => {
             },
         },
     });
-    const { id: requestId } = await prisma.friendRequest.findFirst({
+    const { id } = await prisma.friendRequest.findFirst({
         where: {
             fromUser: from,
             toUser: to,
@@ -474,7 +474,7 @@ app.post("/friend/accept/:from", async (req, res) => {
 
     await prisma.friendRequest.delete({
         where: {
-            id: requestId,
+            id: id,
         },
     });
 
@@ -486,7 +486,7 @@ app.post("/friend/decline/:from", async (req, res) => {
 
     const from = parseInt(req.params.from);
 
-    const { id: requestId } = await prisma.friendRequest.findFirst({
+    const { id } = await prisma.friendRequest.findFirst({
         where: {
             fromUser: from,
             toUser: to,
@@ -498,7 +498,7 @@ app.post("/friend/decline/:from", async (req, res) => {
 
     await prisma.friendRequest.delete({
         where: {
-            id: requestId,
+            id: id,
         },
     });
 

--- a/backend/prisma/migrations/20250630220642_init_friend_request_table/migration.sql
+++ b/backend/prisma/migrations/20250630220642_init_friend_request_table/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "FriendRequest" (
+    "id" SERIAL NOT NULL,
+    "fromUser" INTEGER NOT NULL,
+    "toUser" INTEGER NOT NULL,
+
+    CONSTRAINT "FriendRequest_pkey" PRIMARY KEY ("id")
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,3 +41,9 @@ model UserPastGeohashes {
   timestamp DateTime
   geohash String
 }
+
+model FriendRequest {
+  id Int @id @default(autoincrement())
+  fromUser Int
+  toUser Int
+}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -20,30 +20,40 @@ import { APP_TITLE } from "../constants";
 import type { AllUserData, FriendRequestWithProfile } from "../types";
 import Modal from "./Modal";
 
-// Landing page; allows navigating to profile, map, etc.
+/**
+ *
+ * @returns A landing page where the user can view notifications and navigate out to other pages
+ */
 const Dashboard = () => {
+    // the logged-in user
     const { user } = useUser();
 
-    const navigate = useNavigate();
-
-    const [showingMenu, setShowingMenu] = useState(false);
-
-    const [modalData, setModalData] = useState<AllUserData | null>(null);
-
-    const [friendRequests, setFriendRequests] = useState(
-        Array() as FriendRequestWithProfile[],
-    );
-
+    // logout the user and navigate to login page
     const handleLogout = () => {
         logout();
         navigate("/login");
     };
 
+    const navigate = useNavigate();
+
+    // whether to show profile menu
+    const [showingMenu, setShowingMenu] = useState(false);
+
+    // user data to show in modal; null when modal is hidden
+    const [modalData, setModalData] = useState<AllUserData | null>(null);
+
+    // all active incoming friend requests
+    const [friendRequests, setFriendRequests] = useState(
+        Array() as FriendRequestWithProfile[],
+    );
+
+    // load active friend requests with data on the user who sent them
     const loadFriendRequests = async () => {
         const requests = await getIncomingFriendRequests();
 
         const result = Array() as FriendRequestWithProfile[];
 
+        // iterate over each request, adding an object with its data and profile data to result
         for (const request of requests) {
             const data = await getAllData(request.fromUser);
 
@@ -57,25 +67,29 @@ const Dashboard = () => {
         setFriendRequests(result);
     };
 
+    // load friend requests on component mount
+    useEffect(() => {
+        loadFriendRequests();
+    }, []);
+
+    // accept a friend request and reload display
     const handleAcceptFriend = async (fromId: number) => {
         await acceptFriendRequest(fromId);
 
         await loadFriendRequests();
     };
 
+    // decline a friend request and reload display
     const handleDeclineFriend = async (fromId: number) => {
         await declineFriendRequest(fromId);
 
         await loadFriendRequests();
     };
 
+    // show originating user's profile when their name is clicked in a friend request
     const handleFriendNameClick = (_: React.MouseEvent, data: AllUserData) => {
         setModalData(data);
     };
-
-    useEffect(() => {
-        loadFriendRequests();
-    }, []);
 
     if (user === null) {
         return <LoggedOut></LoggedOut>;

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,14 +1,14 @@
 import styles from "../css/Dashboard.module.css";
 import { useUser } from "../contexts/UserContext";
 import { useNavigate } from "react-router-dom";
-import { logout } from "../utils";
+import { getIncomingFriendRequests, logout } from "../utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
     faUser,
     faChevronDown,
     faArrowRightLong,
 } from "@fortawesome/free-solid-svg-icons";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import LoggedOut from "./LoggedOut";
 import { APP_TITLE } from "../constants";
 
@@ -20,16 +20,31 @@ const Dashboard = () => {
 
     const [showingMenu, setShowingMenu] = useState(false);
 
+    const [friendRequests, setFriendRequests] = useState(Array());
+
     const handleLogout = () => {
         logout();
         navigate("/login");
     };
+
+    useEffect(() => {
+        getIncomingFriendRequests().then((requests) =>
+            setFriendRequests(requests),
+        );
+    }, []);
 
     if (user === null) {
         return <LoggedOut></LoggedOut>;
     } else {
         return (
             <main className={styles.grid}>
+                <div className={styles.friendContainer}>
+                    {friendRequests.map((request) => (
+                        <div className={styles.friendRequest}>
+                            <p>From {request.fromUser}</p>
+                        </div>
+                    ))}
+                </div>
                 <div className={styles.titleContainer}>
                     <h1 className={styles.title}>{APP_TITLE}</h1>
                     <div

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,7 +1,12 @@
 import styles from "../css/Dashboard.module.css";
 import { useUser } from "../contexts/UserContext";
 import { useNavigate } from "react-router-dom";
-import { getIncomingFriendRequests, logout } from "../utils";
+import {
+    acceptFriendRequest,
+    declineFriendRequest,
+    getIncomingFriendRequests,
+    logout,
+} from "../utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
     faUser,
@@ -27,6 +32,22 @@ const Dashboard = () => {
         navigate("/login");
     };
 
+    const handleAcceptFriend = (fromId: number) => {
+        acceptFriendRequest(fromId);
+
+        getIncomingFriendRequests().then((requests) =>
+            setFriendRequests(requests),
+        );
+    };
+
+    const handleDeclineFriend = (fromId: number) => {
+        declineFriendRequest(fromId);
+
+        getIncomingFriendRequests().then((requests) =>
+            setFriendRequests(requests),
+        );
+    };
+
     useEffect(() => {
         getIncomingFriendRequests().then((requests) =>
             setFriendRequests(requests),
@@ -39,9 +60,26 @@ const Dashboard = () => {
         return (
             <main className={styles.grid}>
                 <div className={styles.friendContainer}>
+                    <h2 className={styles.sectionHeader}>Friend Requests</h2>
                     {friendRequests.map((request) => (
                         <div className={styles.friendRequest}>
-                            <p>From {request.fromUser}</p>
+                            <p className={styles.friendText}>
+                                From {request.fromUser}
+                            </p>
+                            <button
+                                className={styles.friendButton}
+                                onClick={() =>
+                                    handleAcceptFriend(request.fromUser)
+                                }>
+                                Accept
+                            </button>
+                            <button
+                                className={styles.friendButton}
+                                onClick={() =>
+                                    handleDeclineFriend(request.fromUser)
+                                }>
+                                Decline
+                            </button>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/components/MapMarker.tsx
+++ b/frontend/src/components/MapMarker.tsx
@@ -81,7 +81,6 @@ const MapMarker = ({ id, location, setModalData }: MapMarkerProps) => {
                                 }
                             })}
                         </div>
-                        <p className={styles.profileBio}>{userData.bio}</p>
                     </div>
                 </div>
             </AdvancedMarker>

--- a/frontend/src/components/MapMarker.tsx
+++ b/frontend/src/components/MapMarker.tsx
@@ -46,42 +46,47 @@ const MapMarker = ({ id, location, setModalData }: MapMarkerProps) => {
         });
     }, []);
 
-    return (
-        <AdvancedMarker position={geoHashToLatLng(location)}>
-            <div
-                className={styles.marker}
-                onClick={handleMarkerClick}>
-                <FontAwesomeIcon
-                    className={styles.markerIcon}
-                    icon={faUser}></FontAwesomeIcon>
-                <div className={styles.profilePopup}>
-                    <h3 className={styles.profileTitle}>
-                        {userData.firstName} {userData.lastName}{" "}
-                        <span className={styles.profilePronouns}>
-                            {userData.pronouns}
-                        </span>
-                    </h3>
-                    <p className={styles.profileMajor}>
-                        {userData.major ?? "(No major)"}
-                    </p>
-                    <div className={styles.interestsContainer}>
-                        {userData.interests.map((value, index) => {
-                            if (value === 1) {
-                                return (
-                                    <p className={styles.profileInterest}>
-                                        {getInterestName(index)}
-                                    </p>
-                                );
-                            } else {
-                                return <></>;
-                            }
-                        })}
+    // if this user has blocked the current user, don't show the marker
+    if (!user || userData.blockedUsers.includes(user.id)) {
+        return <></>;
+    } else {
+        return (
+            <AdvancedMarker position={geoHashToLatLng(location)}>
+                <div
+                    className={styles.marker}
+                    onClick={handleMarkerClick}>
+                    <FontAwesomeIcon
+                        className={styles.markerIcon}
+                        icon={faUser}></FontAwesomeIcon>
+                    <div className={styles.profilePopup}>
+                        <h3 className={styles.profileTitle}>
+                            {userData.firstName} {userData.lastName}{" "}
+                            <span className={styles.profilePronouns}>
+                                {userData.pronouns}
+                            </span>
+                        </h3>
+                        <p className={styles.profileMajor}>
+                            {userData.major ?? "(No major)"}
+                        </p>
+                        <div className={styles.interestsContainer}>
+                            {userData.interests.map((value, index) => {
+                                if (value === 1) {
+                                    return (
+                                        <p className={styles.profileInterest}>
+                                            {getInterestName(index)}
+                                        </p>
+                                    );
+                                } else {
+                                    return <></>;
+                                }
+                            })}
+                        </div>
+                        <p className={styles.profileBio}>{userData.bio}</p>
                     </div>
-                    <p className={styles.profileBio}>{userData.bio}</p>
                 </div>
-            </div>
-        </AdvancedMarker>
-    );
+            </AdvancedMarker>
+        );
+    }
 };
 
 export default MapMarker;

--- a/frontend/src/components/MapMarker.tsx
+++ b/frontend/src/components/MapMarker.tsx
@@ -1,7 +1,7 @@
 import styles from "../css/MapMarker.module.css";
 import { AdvancedMarker } from "@vis.gl/react-google-maps";
 import { useState, useEffect } from "react";
-import type { UserProfile } from "../types";
+import type { AllUserData, UserProfile } from "../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
 import { geoHashToLatLng, getInterestName, getProfile } from "../utils";
@@ -9,6 +9,7 @@ import { geoHashToLatLng, getInterestName, getProfile } from "../utils";
 interface MapMarkerProps {
     id: number;
     location: string;
+    setModalData: React.Dispatch<React.SetStateAction<AllUserData | null>>;
 }
 
 /**
@@ -17,13 +18,24 @@ interface MapMarkerProps {
  * @param location location of the user
  * @returns A marker at the user's location with profile information in a popup on hover
  */
-const MapMarker = ({ id, location }: MapMarkerProps) => {
+const MapMarker = ({ id, location, setModalData }: MapMarkerProps) => {
     // profile of the user represented by this marker
     const [userData, setUserData] = useState<UserProfile>({
         firstName: "",
         lastName: "",
         interests: [],
     });
+
+    const handleMarkerClick = (event: React.MouseEvent) => {
+        event.stopPropagation();
+        console.log("whe");
+        setModalData({
+            id: id,
+            ...userData,
+            friends: [],
+            blockedUsers: [],
+        });
+    };
 
     // fetch user's profile to populate popup
     useEffect(() => {
@@ -36,7 +48,9 @@ const MapMarker = ({ id, location }: MapMarkerProps) => {
 
     return (
         <AdvancedMarker position={geoHashToLatLng(location)}>
-            <div className={styles.marker}>
+            <div
+                className={styles.marker}
+                onClick={handleMarkerClick}>
                 <FontAwesomeIcon
                     className={styles.markerIcon}
                     icon={faUser}></FontAwesomeIcon>

--- a/frontend/src/components/MapMarker.tsx
+++ b/frontend/src/components/MapMarker.tsx
@@ -1,10 +1,11 @@
 import styles from "../css/MapMarker.module.css";
 import { AdvancedMarker } from "@vis.gl/react-google-maps";
 import { useState, useEffect } from "react";
-import type { AllUserData, UserProfile } from "../types";
+import type { AllUserData } from "../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
-import { geoHashToLatLng, getInterestName, getProfile } from "../utils";
+import { geoHashToLatLng, getAllData, getInterestName } from "../utils";
+import { useUser } from "../contexts/UserContext";
 
 interface MapMarkerProps {
     id: number;
@@ -19,30 +20,31 @@ interface MapMarkerProps {
  * @returns A marker at the user's location with profile information in a popup on hover
  */
 const MapMarker = ({ id, location, setModalData }: MapMarkerProps) => {
+
+    const { user } = useUser();
+
     // profile of the user represented by this marker
-    const [userData, setUserData] = useState<UserProfile>({
+    const [userData, setUserData] = useState<AllUserData>({
+        id: id,
         firstName: "",
         lastName: "",
         interests: [],
+        friends: [],
+        blockedUsers: [],
     });
 
     const handleMarkerClick = (event: React.MouseEvent) => {
         event.stopPropagation();
-        console.log("whe");
-        setModalData({
-            id: id,
-            ...userData,
-            friends: [],
-            blockedUsers: [],
-        });
+        if (userData.id !== user?.id) {
+            setModalData(userData);
+        }
+        
     };
 
     // fetch user's profile to populate popup
     useEffect(() => {
-        getProfile(id).then((profile) => {
-            if (profile) {
-                setUserData(profile);
-            }
+        getAllData(id).then((data) => {
+            setUserData(data);
         });
     }, []);
 

--- a/frontend/src/components/MapMarker.tsx
+++ b/frontend/src/components/MapMarker.tsx
@@ -20,7 +20,6 @@ interface MapMarkerProps {
  * @returns A marker at the user's location with profile information in a popup on hover
  */
 const MapMarker = ({ id, location, setModalData }: MapMarkerProps) => {
-
     const { user } = useUser();
 
     // profile of the user represented by this marker
@@ -38,7 +37,6 @@ const MapMarker = ({ id, location, setModalData }: MapMarkerProps) => {
         if (userData.id !== user?.id) {
             setModalData(userData);
         }
-        
     };
 
     // fetch user's profile to populate popup

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -22,10 +22,11 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeftLong } from "@fortawesome/free-solid-svg-icons";
 import { useBeforeUnload, useNavigate } from "react-router-dom";
-import type { UserGeohash } from "../types";
+import type { AllUserData, UserGeohash } from "../types";
 import Slider from "./Slider";
 import { encodeBase32 } from "geohashing";
 import RecommendationList from "./RecommendationList";
+import Modal from "./Modal";
 
 /**
  *
@@ -48,6 +49,9 @@ const MapPage = () => {
 
     // radius in which to show other users
     const [radius, setRadius] = useState(GEOHASH_RADII[0].radius);
+
+    // profile to show in modal; null if not showing
+    const [modalData, setModalData] = useState<AllUserData | null>(null);
 
     // seconds spent at approximately this location
     const timeAtLocation = useRef(0);
@@ -138,6 +142,9 @@ const MapPage = () => {
     } else if (myLocation) {
         return (
             <>
+                <Modal
+                    userData={modalData}
+                    setUserData={setModalData}></Modal>
                 <div className={styles.leftContainer}>
                     <button
                         className={styles.navButton}
@@ -199,7 +206,8 @@ const MapPage = () => {
                     disableDefaultUI={true}>
                     <MapMarker
                         id={user.id}
-                        location={myLocation}></MapMarker>
+                        location={myLocation}
+                        setModalData={setModalData}></MapMarker>
 
                     {otherUsers
                         .filter((userLoc) => {
@@ -214,7 +222,8 @@ const MapPage = () => {
                                 <MapMarker
                                     id={user.userId}
                                     key={user.userId}
-                                    location={user.geohash}></MapMarker>
+                                    location={user.geohash}
+                                    setModalData={setModalData}></MapMarker>
                             );
                         })}
                 </Map>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,29 @@
+import React, { useRef } from "react";
+import styles from "../css/Modal.module.css";
+import type { AllUserData } from "../types";
+
+interface ModalProps {
+    userData: AllUserData | null;
+    setUserData: React.Dispatch<React.SetStateAction<AllUserData | null>>;
+}
+
+const Modal = ({ userData, setUserData }: ModalProps) => {
+    const overlayRef = useRef<HTMLDivElement | null>(null);
+
+    const handleOverlayClick = (event: React.MouseEvent) => {
+        if (event.target === overlayRef.current) {
+            setUserData(null);
+        }
+    };
+
+    return (
+        <div
+            ref={overlayRef}
+            onClick={handleOverlayClick}
+            className={`${styles.overlay} ${userData ? styles.visible : styles.invisible}`}>
+            <div className={styles.modal}></div>
+        </div>
+    );
+};
+
+export default Modal;

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -4,6 +4,12 @@ import Alert from "./Alert";
 import type { AllUserData } from "../types";
 import { getInterestName, sendFriendRequest } from "../utils";
 import { useUser } from "../contexts/UserContext";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+    faUserCheck,
+    faUserXmark,
+    faCircleArrowRight,
+} from "@fortawesome/free-solid-svg-icons";
 
 interface ModalProps {
     userData: AllUserData | null;
@@ -69,20 +75,48 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                     </div>
                     <p className={styles.bio}>{userData.bio}</p>
                     <hr className={styles.bar}></hr>
-                    <div className={styles.friendContainer}>
-                        {userData.friends.includes(user.id) ? (
-                            <input
-                                type="text"
-                                className={styles.input}
-                                placeholder="New message"></input>
-                        ) : (
-                            <button
-                                className={styles.friendButton}
-                                onClick={handleFriendClick}>
-                                Send friend request
-                            </button>
-                        )}
-                    </div>
+                    {userData.friends.includes(user.id) ? (
+                        <>
+                            <div className={styles.friendInfoContainer}>
+                                <FontAwesomeIcon
+                                    icon={faUserCheck}
+                                    color="var(--teal-accent"
+                                    size="lg"></FontAwesomeIcon>
+                                <p className={styles.friendText}>
+                                    You are friends.
+                                </p>
+                            </div>
+                            <div className={styles.friendActionsContainer}>
+                                <input
+                                    type="text"
+                                    className={styles.input}
+                                    placeholder="New message"></input>
+                                <FontAwesomeIcon
+                                    icon={faCircleArrowRight}
+                                    color="var(--teal-accent"
+                                    size="3x"></FontAwesomeIcon>
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <div className={styles.friendInfoContainer}>
+                                <FontAwesomeIcon
+                                    icon={faUserXmark}
+                                    color="var(--teal-accent"
+                                    size="lg"></FontAwesomeIcon>
+                                <p className={styles.friendText}>
+                                    You are not friends.
+                                </p>
+                            </div>
+                            <div className={styles.friendActionsContainer}>
+                                <button
+                                    className={styles.friendButton}
+                                    onClick={handleFriendClick}>
+                                    Send friend request
+                                </button>
+                            </div>
+                        </>
+                    )}
                 </div>
             </div>
         );

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -24,23 +24,42 @@ interface ModalProps {
     setUserData: React.Dispatch<React.SetStateAction<AllUserData | null>>;
 }
 
+/**
+ *
+ * @param userData data to show in modal; null when modal is hidden
+ * @param setUserData state function to update userData; used to hide modal
+ * @returns A modal displaying a user's data overlaid on the content below
+ */
 const Modal = ({ userData, setUserData }: ModalProps) => {
+    // reference to the overlay div itself
     const overlayRef = useRef<HTMLDivElement | null>(null);
 
-    const { user } = useUser();
-
-    const [currentUserData, setCurrentUserData] = useState<AllUserData | null>(
-        null,
-    );
-
-    const [alertText, setAlertText] = useState<string | null>(null);
-
+    // closes modal if the overlay itself is clicked, not its contents
     const handleOverlayClick = (event: React.MouseEvent) => {
         if (event.target === overlayRef.current) {
             setUserData(null);
         }
     };
 
+    // the logged-in user
+    const { user } = useUser();
+
+    // the full user table data for the logged-in user
+    const [currentUserData, setCurrentUserData] = useState<AllUserData | null>(
+        null,
+    );
+
+    // once user is loaded from context, get user's data
+    useEffect(() => {
+        if (user) {
+            getAllData(user.id).then((data) => setCurrentUserData(data));
+        }
+    }, [user]);
+
+    // message to show in alert (null when alert is not showing)
+    const [alertText, setAlertText] = useState<string | null>(null);
+
+    // try to send a friend request when button is clicked
     const handleFriendClick = () => {
         if (userData) {
             sendFriendRequest(userData.id).then((success) =>
@@ -53,6 +72,7 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
         }
     };
 
+    // block user when button is clicked
     const handleBlockClick = () => {
         if (userData) {
             blockUser(userData.id);
@@ -60,18 +80,13 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
         }
     };
 
+    // unblock user when button is clicked
     const handleUnblockClick = () => {
         if (userData) {
             unblockUser(userData.id);
             setAlertText("Successfully unblocked user.");
         }
     };
-
-    useEffect(() => {
-        if (user) {
-            getAllData(user.id).then((data) => setCurrentUserData(data));
-        }
-    }, [user]);
 
     if (userData && currentUserData) {
         return (
@@ -109,16 +124,16 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                     <hr className={styles.bar}></hr>
                     {currentUserData.friends.includes(userData.id) ? (
                         <>
-                            <div className={styles.friendInfoContainer}>
+                            <div className={styles.infoContainer}>
                                 <FontAwesomeIcon
                                     icon={faUserCheck}
                                     color="var(--teal-accent"
                                     size="lg"></FontAwesomeIcon>
-                                <p className={styles.friendText}>
+                                <p className={styles.infoText}>
                                     You are friends.
                                 </p>
                             </div>
-                            <div className={styles.friendActionsContainer}>
+                            <div className={styles.actionsContainer}>
                                 <input
                                     type="text"
                                     className={styles.input}
@@ -131,18 +146,18 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                         </>
                     ) : (
                         <>
-                            <div className={styles.friendInfoContainer}>
+                            <div className={styles.infoContainer}>
                                 <FontAwesomeIcon
                                     icon={faUserXmark}
                                     color="var(--teal-accent"
                                     size="lg"></FontAwesomeIcon>
-                                <p className={styles.friendText}>
+                                <p className={styles.infoText}>
                                     You are not friends.
                                 </p>
                             </div>
-                            <div className={styles.friendActionsContainer}>
+                            <div className={styles.actionsContainer}>
                                 <button
-                                    className={styles.friendButton}
+                                    className={styles.button}
                                     onClick={handleFriendClick}>
                                     Send friend request
                                 </button>
@@ -151,19 +166,19 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                     )}
                     {currentUserData.blockedUsers.includes(userData.id) ? (
                         <>
-                            <div className={styles.friendInfoContainer}>
+                            <div className={styles.infoContainer}>
                                 <FontAwesomeIcon
                                     icon={faShieldHalved}
                                     color="var(--teal-accent)"
                                     size="lg"></FontAwesomeIcon>
-                                <p className={styles.friendText}>
+                                <p className={styles.infoText}>
                                     You have blocked this user. They cannot see
                                     your location or message you.
                                 </p>
                             </div>
-                            <div className={styles.friendActionsContainer}>
+                            <div className={styles.actionsContainer}>
                                 <button
-                                    className={styles.friendButton}
+                                    className={styles.button}
                                     onClick={handleUnblockClick}>
                                     Unblock user
                                 </button>
@@ -171,19 +186,19 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                         </>
                     ) : (
                         <>
-                            <div className={styles.friendInfoContainer}>
+                            <div className={styles.infoContainer}>
                                 <FontAwesomeIcon
                                     icon={faUserShield}
                                     color="var(--teal-accent)"
                                     size="lg"></FontAwesomeIcon>
-                                <p className={styles.friendText}>
+                                <p className={styles.infoText}>
                                     This user can see your location and request
                                     to message you.
                                 </p>
                             </div>
-                            <div className={styles.friendActionsContainer}>
+                            <div className={styles.actionsContainer}>
                                 <button
-                                    className={styles.friendButton}
+                                    className={styles.button}
                                     onClick={handleBlockClick}>
                                     Block user
                                 </button>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,6 +1,8 @@
 import React, { useRef } from "react";
 import styles from "../css/Modal.module.css";
 import type { AllUserData } from "../types";
+import { getInterestName } from "../utils";
+import { useUser } from "../contexts/UserContext";
 
 interface ModalProps {
     userData: AllUserData | null;
@@ -10,20 +12,63 @@ interface ModalProps {
 const Modal = ({ userData, setUserData }: ModalProps) => {
     const overlayRef = useRef<HTMLDivElement | null>(null);
 
+    const { user } = useUser();
+
     const handleOverlayClick = (event: React.MouseEvent) => {
         if (event.target === overlayRef.current) {
             setUserData(null);
         }
     };
 
-    return (
-        <div
-            ref={overlayRef}
-            onClick={handleOverlayClick}
-            className={`${styles.overlay} ${userData ? styles.visible : styles.invisible}`}>
-            <div className={styles.modal}></div>
-        </div>
-    );
+    if (user && userData) {
+        return (
+            <div
+                ref={overlayRef}
+                onClick={handleOverlayClick}
+                className={styles.overlay}>
+                <div className={styles.modal}>
+                    <h2 className={styles.title}>
+                        {userData.firstName} {userData.lastName}{" "}
+                        <span className={styles.pronouns}>
+                            {userData.pronouns}
+                        </span>
+                    </h2>
+                    <p className={styles.major}>
+                        {userData.major ?? "(No major)"}
+                    </p>
+                    <div className={styles.interestsContainer}>
+                        {userData.interests.map((value, index) => {
+                            if (value === 1) {
+                                return (
+                                    <p className={styles.interest}>
+                                        {getInterestName(index)}
+                                    </p>
+                                );
+                            } else {
+                                return <></>;
+                            }
+                        })}
+                    </div>
+                    <p className={styles.bio}>{userData.bio}</p>
+                    <hr className={styles.bar}></hr>
+                    <div className={styles.friendContainer}>
+                        {userData.friends.includes(user.id) ? (
+                            <input
+                                type="text"
+                                className={styles.input}
+                                placeholder="New message"></input>
+                        ) : (
+                            <button className={styles.friendButton}>
+                                Send friend request
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+        );
+    } else {
+        return <></>;
+    }
 };
 
 export default Modal;

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -49,11 +49,16 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
         null,
     );
 
+    const loadCurrentUserData = async () => {
+        if (user) {
+            const data = await getAllData(user.id);
+            setCurrentUserData(data);
+        }
+    };
+
     // once user is loaded from context, get user's data
     useEffect(() => {
-        if (user) {
-            getAllData(user.id).then((data) => setCurrentUserData(data));
-        }
+        loadCurrentUserData();
     }, [user]);
 
     // message to show in alert (null when alert is not showing)
@@ -73,18 +78,20 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
     };
 
     // block user when button is clicked
-    const handleBlockClick = () => {
+    const handleBlockClick = async () => {
         if (userData) {
-            blockUser(userData.id);
+            await blockUser(userData.id);
             setAlertText("Successfully blocked user.");
+            await loadCurrentUserData();
         }
     };
 
     // unblock user when button is clicked
-    const handleUnblockClick = () => {
+    const handleUnblockClick = async () => {
         if (userData) {
-            unblockUser(userData.id);
+            await unblockUser(userData.id);
             setAlertText("Successfully unblocked user.");
+            await loadCurrentUserData();
         }
     };
 

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,14 +1,22 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import styles from "../css/Modal.module.css";
 import Alert from "./Alert";
 import type { AllUserData } from "../types";
-import { getInterestName, sendFriendRequest } from "../utils";
+import {
+    blockUser,
+    getAllData,
+    getInterestName,
+    sendFriendRequest,
+    unblockUser,
+} from "../utils";
 import { useUser } from "../contexts/UserContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
     faUserCheck,
     faUserXmark,
     faCircleArrowRight,
+    faUserShield,
+    faShieldHalved,
 } from "@fortawesome/free-solid-svg-icons";
 
 interface ModalProps {
@@ -20,6 +28,10 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
     const overlayRef = useRef<HTMLDivElement | null>(null);
 
     const { user } = useUser();
+
+    const [currentUserData, setCurrentUserData] = useState<AllUserData | null>(
+        null,
+    );
 
     const [alertText, setAlertText] = useState<string | null>(null);
 
@@ -41,7 +53,27 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
         }
     };
 
-    if (user && userData) {
+    const handleBlockClick = () => {
+        if (userData) {
+            blockUser(userData.id);
+            setAlertText("Successfully blocked user.");
+        }
+    };
+
+    const handleUnblockClick = () => {
+        if (userData) {
+            unblockUser(userData.id);
+            setAlertText("Successfully unblocked user.");
+        }
+    };
+
+    useEffect(() => {
+        if (user) {
+            getAllData(user.id).then((data) => setCurrentUserData(data));
+        }
+    }, [user]);
+
+    if (userData && currentUserData) {
         return (
             <div
                 ref={overlayRef}
@@ -75,7 +107,7 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                     </div>
                     <p className={styles.bio}>{userData.bio}</p>
                     <hr className={styles.bar}></hr>
-                    {userData.friends.includes(user.id) ? (
+                    {currentUserData.friends.includes(userData.id) ? (
                         <>
                             <div className={styles.friendInfoContainer}>
                                 <FontAwesomeIcon
@@ -113,6 +145,47 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                                     className={styles.friendButton}
                                     onClick={handleFriendClick}>
                                     Send friend request
+                                </button>
+                            </div>
+                        </>
+                    )}
+                    {currentUserData.blockedUsers.includes(userData.id) ? (
+                        <>
+                            <div className={styles.friendInfoContainer}>
+                                <FontAwesomeIcon
+                                    icon={faShieldHalved}
+                                    color="var(--teal-accent)"
+                                    size="lg"></FontAwesomeIcon>
+                                <p className={styles.friendText}>
+                                    You have blocked this user. They cannot see
+                                    your location or message you.
+                                </p>
+                            </div>
+                            <div className={styles.friendActionsContainer}>
+                                <button
+                                    className={styles.friendButton}
+                                    onClick={handleUnblockClick}>
+                                    Unblock user
+                                </button>
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <div className={styles.friendInfoContainer}>
+                                <FontAwesomeIcon
+                                    icon={faUserShield}
+                                    color="var(--teal-accent)"
+                                    size="lg"></FontAwesomeIcon>
+                                <p className={styles.friendText}>
+                                    This user can see your location and request
+                                    to message you.
+                                </p>
+                            </div>
+                            <div className={styles.friendActionsContainer}>
+                                <button
+                                    className={styles.friendButton}
+                                    onClick={handleBlockClick}>
+                                    Block user
                                 </button>
                             </div>
                         </>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,7 +1,8 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import styles from "../css/Modal.module.css";
+import Alert from "./Alert";
 import type { AllUserData } from "../types";
-import { getInterestName } from "../utils";
+import { getInterestName, sendFriendRequest } from "../utils";
 import { useUser } from "../contexts/UserContext";
 
 interface ModalProps {
@@ -14,9 +15,23 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
 
     const { user } = useUser();
 
+    const [alertText, setAlertText] = useState<string | null>(null);
+
     const handleOverlayClick = (event: React.MouseEvent) => {
         if (event.target === overlayRef.current) {
             setUserData(null);
+        }
+    };
+
+    const handleFriendClick = () => {
+        if (userData) {
+            sendFriendRequest(userData.id).then((success) =>
+                setAlertText(
+                    success
+                        ? "Request sent."
+                        : "A friend request between you already exists.",
+                ),
+            );
         }
     };
 
@@ -26,6 +41,9 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                 ref={overlayRef}
                 onClick={handleOverlayClick}
                 className={styles.overlay}>
+                <Alert
+                    alertText={alertText}
+                    setAlertText={setAlertText}></Alert>
                 <div className={styles.modal}>
                     <h2 className={styles.title}>
                         {userData.firstName} {userData.lastName}{" "}
@@ -58,7 +76,9 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                                 className={styles.input}
                                 placeholder="New message"></input>
                         ) : (
-                            <button className={styles.friendButton}>
+                            <button
+                                className={styles.friendButton}
+                                onClick={handleFriendClick}>
                                 Send friend request
                             </button>
                         )}

--- a/frontend/src/css/Alert.module.css
+++ b/frontend/src/css/Alert.module.css
@@ -28,6 +28,7 @@
     animation-name: alert-slide;
     animation-timing-function: ease;
     animation-fill-mode: both;
+    z-index: 12;
 }
 
 .alertText {

--- a/frontend/src/css/Dashboard.module.css
+++ b/frontend/src/css/Dashboard.module.css
@@ -2,6 +2,8 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     height: 100vh;
+    padding: 1rem;
+    box-sizing: border-box;
 }
 
 .titleContainer {
@@ -12,13 +14,13 @@
     justify-content: flex-end;
     align-items: center;
     gap: 1rem;
-    margin: 1rem;
     position: relative;
     align-self: start;
 }
 
 .title {
-    font-size: 36px;
+    font-size: 42px;
+    margin: 0;
 }
 
 .userMenuButton {
@@ -69,9 +71,50 @@
     color: var(--teal-accent);
     grid-column-start: 2;
     grid-column-end: 3;
-    margin: 1rem;
     height: fit-content;
     width: fit-content;
     align-self: end;
     justify-self: end;
+}
+
+.sectionHeader {
+    font-size: 32px;
+    margin: 0;
+}
+
+.friendContainer {
+    display: flex;
+    flex-flow: column nowrap;
+    grid-column-start: 1;
+    grid-column-end: 2;
+    width: 30vw;
+    gap: 1rem;
+}
+
+.friendRequest {
+    background-color: var(--tan-background);
+    padding: 1rem;
+    box-sizing: border-box;
+    border-radius: 1rem;
+    display: grid;
+    column-gap: 1rem;
+    row-gap: 1rem;
+    grid-template-columns: 1fr 1fr;
+}
+
+.friendText {
+    font-size: 20px;
+    margin: 0;
+    grid-column-start: 1;
+    grid-column-end: 3;
+}
+
+.friendButton {
+    font-family: inherit;
+    font-size: 18px;
+    color: var(--teal-accent);
+    background-color: transparent;
+    border: var(--teal-accent) 2px solid;
+    padding: 0.75rem 2rem;
+    border-radius: 2rem;
 }

--- a/frontend/src/css/Dashboard.module.css
+++ b/frontend/src/css/Dashboard.module.css
@@ -118,3 +118,12 @@
     padding: 0.75rem 2rem;
     border-radius: 2rem;
 }
+
+.friendName {
+    color: var(--teal-accent);
+    font-weight: bold;
+}
+
+.friendName:hover {
+    text-decoration: underline;
+}

--- a/frontend/src/css/MapMarker.module.css
+++ b/frontend/src/css/MapMarker.module.css
@@ -17,7 +17,6 @@
     display: none;
     transform: translate(8%, -110%);
     width: 32rem;
-    height: 16rem;
     background-color: var(--tan-background);
     border-radius: 2rem;
     padding: 2rem;
@@ -66,8 +65,4 @@
     border-radius: 1rem;
     border: var(--teal-accent) 1px solid;
     padding: 0.25rem 1rem;
-}
-
-.profileBio {
-    font-size: 18px;
 }

--- a/frontend/src/css/Modal.module.css
+++ b/frontend/src/css/Modal.module.css
@@ -1,0 +1,28 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(30, 30, 30, 0.5);
+    z-index: 10;
+}
+
+.invisible {
+    display: none;
+}
+
+.visible {
+    display: block;
+}
+
+.modal {
+    position: fixed;
+    top: 10vh;
+    left: 10vw;
+    width: 80vw;
+    height: 80vh;
+    background-color: var(--tan-background);
+    z-index: 11;
+    border-radius: 2rem;
+}

--- a/frontend/src/css/Modal.module.css
+++ b/frontend/src/css/Modal.module.css
@@ -69,6 +69,29 @@
     border: var(--teal-accent) 0.5px inset;
 }
 
+.friendInfoContainer {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.friendText {
+    font-size: 20px;
+    margin: 0;
+    color: var(--teal-accent);
+}
+
+.friendActionsContainer {
+    width: 100%;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    gap: 0.5rem;
+    align-items: center;
+}
+
 .friendButton {
     font-family: inherit;
     background-color: transparent;
@@ -79,4 +102,20 @@
     padding: 0.75rem 0;
     box-sizing: border-box;
     border-radius: 2rem;
+}
+
+.input {
+    font-family: inherit;
+    color: inherit;
+    padding: 0.75rem 1.25rem;
+    border: var(--teal-accent) 2px solid;
+    border-radius: 2rem;
+    font-size: inherit;
+    width: 100%;
+    box-sizing: border-box;
+    font-size: 20px;
+}
+
+.input:focus-visible {
+    outline: none;
 }

--- a/frontend/src/css/Modal.module.css
+++ b/frontend/src/css/Modal.module.css
@@ -69,7 +69,7 @@
     border: var(--teal-accent) 0.5px inset;
 }
 
-.friendInfoContainer {
+.infoContainer {
     display: flex;
     flex-flow: row nowrap;
     justify-content: flex-start;
@@ -77,13 +77,13 @@
     align-items: center;
 }
 
-.friendText {
+.infoText {
     font-size: 20px;
     margin: 0;
     color: var(--teal-accent);
 }
 
-.friendActionsContainer {
+.actionsContainer {
     width: 100%;
     display: flex;
     flex-flow: row nowrap;
@@ -92,7 +92,7 @@
     align-items: center;
 }
 
-.friendButton {
+.button {
     font-family: inherit;
     background-color: transparent;
     border: var(--teal-accent) 2px solid;

--- a/frontend/src/css/Modal.module.css
+++ b/frontend/src/css/Modal.module.css
@@ -8,21 +8,75 @@
     z-index: 10;
 }
 
-.invisible {
-    display: none;
-}
-
-.visible {
-    display: block;
-}
-
 .modal {
     position: fixed;
-    top: 10vh;
-    left: 10vw;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     width: 80vw;
-    height: 80vh;
     background-color: var(--tan-background);
     z-index: 11;
+    border-radius: 2rem;
+    box-sizing: border-box;
+    padding: 2rem;
+    display: flex;
+    flex-flow: column nowrap;
+    gap: 2rem;
+}
+
+.title {
+    font-size: 24px;
+    font-weight: bold;
+    margin: 0;
+}
+
+.pronouns {
+    font-size: 20px;
+    font-weight: bold;
+    color: var(--teal-accent);
+    margin: 0;
+}
+
+.major {
+    font-size: 20px;
+    margin: 0;
+}
+
+.interestsContainer {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 0.5rem;
+    font-size: 20px;
+    color: var(--teal-accent);
+    height: fit-content;
+}
+
+.interest {
+    margin: 0;
+    border-radius: 1rem;
+    border: var(--teal-accent) 1px solid;
+    padding: 0.25rem 1rem;
+}
+
+.bio {
+    font-size: 20px;
+    margin: 0;
+}
+
+.bar {
+    width: 100%;
+    height: 0px;
+    border: var(--teal-accent) 0.5px inset;
+}
+
+.friendButton {
+    font-family: inherit;
+    background-color: transparent;
+    border: var(--teal-accent) 2px solid;
+    color: var(--teal-accent);
+    font-size: 20px;
+    width: 100%;
+    padding: 0.75rem 0;
+    box-sizing: border-box;
     border-radius: 2rem;
 }

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -11,6 +11,19 @@ export interface UserProfile {
     bio?: string;
 }
 
+export interface AllUserData {
+    id: number;
+    firstName: string;
+    lastName: string;
+    pronouns?: string;
+    age?: number;
+    major?: string;
+    interests: number[];
+    bio?: string;
+    friends: number[];
+    blockedUsers: number[];
+}
+
 /**
  * Represents the logged-in user's id and email for authentication on each page
  */

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -101,3 +101,16 @@ export interface PlaceRecUserData {
     friend: boolean;
     interestAngle: number;
 }
+
+export interface FriendRequest {
+    id: number;
+    fromUser: number;
+    toUser: number;
+}
+
+export interface FriendRequestWithProfile {
+    id: number;
+    fromUser: number;
+    fromUserData: AllUserData;
+    toUser: number;
+}

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -550,6 +550,11 @@ export const recommendPlaces = async (
     return result.sort(sortRecommendations);
 };
 
+/**
+ *
+ * @param to id of the user to whom the request is being sent
+ * @returns true if the request was made; false if there is already an active request between the logged-in user and to
+ */
 export const sendFriendRequest = async (to: number) => {
     const response = await fetch(
         `${import.meta.env.VITE_SERVER_URL}/friend/${to}`,
@@ -563,6 +568,10 @@ export const sendFriendRequest = async (to: number) => {
     return response.ok;
 };
 
+/**
+ *
+ * @returns all active friend requests to the logged-in user
+ */
 export const getIncomingFriendRequests = async () => {
     const response = await fetch(`${import.meta.env.VITE_SERVER_URL}/friend`, {
         credentials: "include",
@@ -572,6 +581,10 @@ export const getIncomingFriendRequests = async () => {
     return json;
 };
 
+/**
+ *
+ * @param from id of the user whom the request is from
+ */
 export const acceptFriendRequest = async (from: number) => {
     await fetch(`${import.meta.env.VITE_SERVER_URL}/friend/accept/${from}`, {
         method: "post",
@@ -580,6 +593,10 @@ export const acceptFriendRequest = async (from: number) => {
     });
 };
 
+/**
+ *
+ * @param from id of the user whom the request is from
+ */
 export const declineFriendRequest = async (from: number) => {
     await fetch(`${import.meta.env.VITE_SERVER_URL}/friend/decline/${from}`, {
         method: "post",

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -587,3 +587,27 @@ export const declineFriendRequest = async (from: number) => {
         credentials: "include",
     });
 };
+
+/**
+ *
+ * @param id id of the user to block; if this is a friend, the friend relationship will be removed
+ */
+export const blockUser = async (id: number) => {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/block/${id}`, {
+        method: "post",
+        mode: "cors",
+        credentials: "include",
+    });
+};
+
+/**
+ *
+ * @param id id of the currently blocked user to unblock
+ */
+export const unblockUser = async (id: number) => {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/unblock/${id}`, {
+        method: "post",
+        mode: "cors",
+        credentials: "include",
+    });
+};

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -7,6 +7,7 @@ import type {
     PlaceRecUserData,
     PlaceHistory,
     AllUserData,
+    FriendRequest,
 } from "./types";
 import {
     COUNT_WEIGHT,
@@ -567,7 +568,7 @@ export const getIncomingFriendRequests = async () => {
         credentials: "include",
     });
 
-    const json = await response.json();
+    const json = (await response.json()) as FriendRequest[];
     return json;
 };
 

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -6,6 +6,7 @@ import type {
     PlaceRecData,
     PlaceRecUserData,
     PlaceHistory,
+    AllUserData,
 } from "./types";
 import {
     COUNT_WEIGHT,
@@ -139,6 +140,18 @@ const interests = [
  */
 export const getInterestName = (id: number) => {
     return interests[id];
+};
+
+export const getAllData = async (userId: number) => {
+    const response = await fetch(
+        `${import.meta.env.VITE_SERVER_URL}/user/details/${userId}`,
+        {
+            credentials: "include",
+        },
+    );
+
+    const json = (await response.json()) as AllUserData;
+    return json;
 };
 
 /**

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -548,3 +548,25 @@ export const recommendPlaces = async (
     // sort results
     return result.sort(sortRecommendations);
 };
+
+export const sendFriendRequest = async (to: number) => {
+    const response = await fetch(
+        `${import.meta.env.VITE_SERVER_URL}/friend/${to}`,
+        {
+            method: "post",
+            mode: "cors",
+            credentials: "include",
+        },
+    );
+
+    return response.ok;
+};
+
+export const getIncomingFriendRequests = async () => {
+    const response = await fetch(`${import.meta.env.VITE_SERVER_URL}/friend`, {
+        credentials: "include",
+    });
+
+    const json = await response.json();
+    return json;
+};

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -570,3 +570,19 @@ export const getIncomingFriendRequests = async () => {
     const json = await response.json();
     return json;
 };
+
+export const acceptFriendRequest = async (from: number) => {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/friend/accept/${from}`, {
+        method: "post",
+        mode: "cors",
+        credentials: "include",
+    });
+};
+
+export const declineFriendRequest = async (from: number) => {
+    await fetch(`${import.meta.env.VITE_SERVER_URL}/friend/decline/${from}`, {
+        method: "post",
+        mode: "cors",
+        credentials: "include",
+    });
+};


### PR DESCRIPTION
## Description
- Add a modal view of another user's profile that shows when their map marker (or name on a friend request) is clicked
- Add FriendRequest table and the ability to send a friend request to another user, who then must accept or decline it
- Add the ability to block another user, which removes a friendship relation if you had one and prevents them from seeing your marker on the map
### Future work
- A text box appears when you have friended someone, but it has no functionality; this is a placeholder for once messaging is implemented
- As shown in the video below, your location is not immediately hidden from the blocked user because data is only fetched in the 5 second interval, but this is probably fine for now since the blocked user won't get any new information about your location
- Blocking someone should hide your messaging history from view or something similar; more details to be worked out in the implementation
- The modal UI can be improved

## Milestones
 - Closes #19

## Resources
- [Working with arrays in Prisma](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-scalar-lists-arrays)

## Test Plan
[Loom video](https://www.loom.com/share/a3d756199eff444bb00de433991d51d1?sid=6518d908-0a71-47d7-a09a-082f85ecd276)

Here I have two windows open, each with a different browser session and different user logged in. I can send friend requests between them, and blocking one results in that user not being able to see the first's location. (If present at the exact same location, another user's marker generally covers one's own, so if I hover and see my own profile (and check the DOM), I know the other user is not on the map).
