### PR TITLE
Implement database session storage and deploy site

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,7 +6,10 @@ const app = express();
 app.use(express.json());
 app.use(
     cors({
-        origin: "http://localhost:5173",
+        origin: [
+            "http://localhost:5173",
+            "https://find-a-friend-ufeh.onrender.com",
+        ],
         credentials: true,
     }),
 );

--- a/backend/index.js
+++ b/backend/index.js
@@ -9,7 +9,7 @@ app.use(
     cors({
         origin: [
             "http://localhost:5173",
-            "https://find-a-friend-ufeh.onrender.com",
+            "https://find-a-friend-site.onrender.com",
         ],
         credentials: true,
     }),

--- a/backend/index.js
+++ b/backend/index.js
@@ -55,6 +55,7 @@ app.use(
         }),
         cookie: {
             maxAge: SESSION_TIMEOUT,
+            sameSite: "none",
         },
     }),
 );

--- a/backend/index.js
+++ b/backend/index.js
@@ -38,12 +38,18 @@ const loginLimiter = rateLimit({
 });
 
 // setup session middleware and cookie settings
+
+const { PrismaSessionStore } = require("@quixo3/prisma-session-store");
+
 const session = require("express-session");
 app.use(
     session({
         secret: process.env.VITE_SESSION_SECRET,
         resave: false,
         saveUninitialized: false,
+        store: new PrismaSessionStore(prisma, {
+            dbRecordIdIsSessionId: true,
+        }),
         cookie: {
             maxAge: SESSION_TIMEOUT,
         },

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ const express = require("express");
 const cors = require("cors");
 
 const app = express();
+app.set("trust proxy", 1);
 app.use(express.json());
 app.use(
     cors({
@@ -55,7 +56,8 @@ app.use(
         }),
         cookie: {
             maxAge: SESSION_TIMEOUT,
-            sameSite: "none",
+            sameSite: process.env.VITE_ENV_TYPE === "production" ? "none" : "lax",
+            secure: process.env.VITE_ENV_TYPE === "production" ? true : false,
         },
     }),
 );

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@prisma/client": "^6.10.0",
+                "@quixo3/prisma-session-store": "^3.1.13",
                 "bcrypt": "^6.0.0",
                 "cors": "^2.8.5",
                 "express": "^5.1.0",
@@ -18,6 +19,27 @@
             },
             "devDependencies": {
                 "prisma": "^6.10.0"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@paralleldrive/cuid2": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+            "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "^1.1.5"
             }
         },
         "node_modules/@prisma/client": {
@@ -100,6 +122,24 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "6.10.0"
+            }
+        },
+        "node_modules/@quixo3/prisma-session-store": {
+            "version": "3.1.13",
+            "resolved": "https://registry.npmjs.org/@quixo3/prisma-session-store/-/prisma-session-store-3.1.13.tgz",
+            "integrity": "sha512-EAuOvYAaAsQ0OqxkdJG/Qs3cxlT4VV8SFHjtsA3G01uB1b6r7xftX3oeg7mcG0HN/DI1qOqwvy3YFoJ38ls0iA==",
+            "license": "MIT",
+            "dependencies": {
+                "@paralleldrive/cuid2": "^2.2.0",
+                "ts-dedent": "^2.2.0",
+                "type-fest": "^2.5.2"
+            },
+            "engines": {
+                "node": ">=12.0"
+            },
+            "peerDependencies": {
+                "@prisma/client": ">=2.16.1",
+                "express-session": ">=1.17.1"
             }
         },
         "node_modules/accepts": {
@@ -1036,6 +1076,27 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/ts-dedent": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+            "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.10"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/type-is": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     },
     "dependencies": {
         "@prisma/client": "^6.10.0",
+        "@quixo3/prisma-session-store": "^3.1.13",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",

--- a/backend/prisma/migrations/20250707223844_init_session_table/migration.sql
+++ b/backend/prisma/migrations/20250707223844_init_session_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "sid" TEXT NOT NULL,
+    "data" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_sid_key" ON "Session"("sid");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -57,3 +57,10 @@ model Message {
   timestamp DateTime
   read Boolean @default(false)
 }
+
+model Session {
+  id String @id
+  sid String @unique
+  data String
+  expiresAt DateTime
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,11 +5,11 @@
         <link
             rel="icon"
             type="image/svg+xml"
-            href="/vite.svg" />
+            href="/map-marker.svg" />
         <meta
             name="viewport"
             content="width=device-width, initial-scale=1.0" />
-        <title>Vite + React + TS</title>
+        <title>Find a Friend</title>
     </head>
     <body>
         <div id="root"></div>

--- a/frontend/map-marker.svg
+++ b/frontend/map-marker.svg
@@ -1,0 +1,11 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#007681">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M18 16.0156C19.2447 16.5445 20 17.2392 20 18C20 19.6568 16.4183 21 12 21C7.58172 21 4 19.6568 4 18C4 17.2392 4.75527 16.5445 6 16.0156" stroke="#007681" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+<path d="M17 8.44444C17 11.5372 12 17 12 17C12 17 7 11.5372 7 8.44444C7 5.35165 9.23858 3 12 3C14.7614 3 17 5.35165 17 8.44444Z" stroke="#007681" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+<circle cx="12" cy="8" r="1" stroke="#007681" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+</g>
+</svg>


### PR DESCRIPTION
## Description
- Make backend changes necessary for the site to work in production on Render: add the url of the deployed frontend as an allowed origin and set the session cookie `sameSite` and `secure` properties
- Set `express-session` store to a `PrismaSessionStore` and create `Session` table to store session data in the database, as `MemoryStore` is unreliable in production
### Future work
- The site runs slower on Render, which is something I've experienced with all my projects deployed there. This creates the opportunity to implement one of the required capstone features: a loading state. I could test this out while the site is checking for an active session, loading the map, loading place recommendations, or elsewhere.

## Milestones
- Closes #24 

## Resources
[express-session docs](https://www.npmjs.com/package/express-session)
[prisma-session-store docs](https://www.npmjs.com/package/@quixo3/prisma-session-store)

## Test Plan
[The working deployed site](https://find-a-friend-site.onrender.com/)
I tested the backend alone with Insomnia first. On the frontend, I then tested that I stay logged in when navigating to different pages and that viewing the map and editing my profile work.
