### PR TITLE
Improve messaging

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -737,6 +737,20 @@ app.get("/messages/:other/:cursor", authenticate, async (req, res) => {
             },
         });
 
+        // mark messages sent to the current user as read
+        for (const id of messages
+            .filter((element) => element.toUser === userId)
+            .map((element) => element.id)) {
+            await prisma.message.update({
+                where: {
+                    id: id,
+                },
+                data: {
+                    read: true,
+                },
+            });
+        }
+
         res.json(messages);
     } else {
         // if the id of the oldest already fetched message is given, take the first 10 messages before that
@@ -763,7 +777,58 @@ app.get("/messages/:other/:cursor", authenticate, async (req, res) => {
             },
         });
 
+        // mark messages sent to the current user as read
+        for (const id of messages
+            .filter((element) => element.toUser === userId)
+            .map((element) => element.id)) {
+            await prisma.message.update({
+                where: {
+                    id: id,
+                },
+                data: {
+                    read: true,
+                },
+            });
+        }
+
         res.json(messages);
+    }
+});
+
+app.get("/unreadMessages/:other", authenticate, async (req, res) => {
+    const userId = req.session.userId;
+
+    const otherId = parseInt(req.params.other);
+
+    const unreadCount = await prisma.message.count({
+        where: {
+            fromUser: otherId,
+            toUser: userId,
+            read: false,
+        },
+    });
+
+    if (unreadCount > 0) {
+        const latestUnread = await prisma.message.findFirst({
+            take: 1,
+            where: {
+                fromUser: otherId,
+                toUser: userId,
+                read: false,
+            },
+            orderBy: {
+                timestamp: "desc",
+            },
+        });
+
+        res.json({
+            unreadCount: unreadCount,
+            latestUnread: latestUnread.text,
+        });
+    } else {
+        res.json({
+            unreadCount: unreadCount,
+        });
     }
 });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -795,6 +795,7 @@ app.get("/messages/:other/:cursor", authenticate, async (req, res) => {
     }
 });
 
+// get the number of unread messages from the other user and the latest unread message if one exists
 app.get("/unreadMessages/:other", authenticate, async (req, res) => {
     const userId = req.session.userId;
 
@@ -865,6 +866,10 @@ app.post("/messages/:to", authenticate, async (req, res) => {
     const to = parseInt(req.params.to);
 
     const { text } = req.body;
+
+    if (!text) {
+        return res.status(400).send("Message text is required");
+    }
 
     const newMessage = await prisma.message.create({
         data: {

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -6,6 +6,7 @@ import {
     declineFriendRequest,
     getAllData,
     getIncomingFriendRequests,
+    getMessagesPreviews,
     logout,
 } from "../utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -17,7 +18,11 @@ import {
 import { useEffect, useState } from "react";
 import LoggedOut from "./LoggedOut";
 import { APP_TITLE } from "../constants";
-import type { AllUserData, FriendRequestWithProfile } from "../types";
+import type {
+    AllUserData,
+    FriendRequestWithProfile,
+    MessagesPreview,
+} from "../types";
 import Modal from "./Modal";
 
 /**
@@ -47,6 +52,11 @@ const Dashboard = () => {
         Array() as FriendRequestWithProfile[],
     );
 
+    // all friends who have sent the user as-yet-unread messages
+    const [unreadMessages, setUnreadMessages] = useState(
+        Array() as MessagesPreview[],
+    );
+
     // load active friend requests with data on the user who sent them
     const loadFriendRequests = async () => {
         const requests = await getIncomingFriendRequests();
@@ -67,10 +77,15 @@ const Dashboard = () => {
         setFriendRequests(result);
     };
 
-    // load friend requests on component mount
+    // load friend requests and message previews on component mount
     useEffect(() => {
-        loadFriendRequests();
-    }, []);
+        if (user) {
+            loadFriendRequests();
+            getMessagesPreviews(user.id).then((data) => {
+                setUnreadMessages(data);
+            });
+        }
+    }, [user]);
 
     // accept a friend request and reload display
     const handleAcceptFriend = async (fromId: number) => {
@@ -128,6 +143,27 @@ const Dashboard = () => {
     const messagesSection = (
         <div className={styles.messagesContainer}>
             <h2 className={styles.sectionHeader}>Messages</h2>
+            {unreadMessages.map((preview) => (
+                <div
+                    key={preview.friendId}
+                    className={styles.messagesPreview}>
+                    <p className={styles.previewText}>
+                        {preview.latestUnread}
+                        {preview.unreadCount > 1 && (
+                            <span className={styles.tealText}>
+                                {" "}
+                                and {preview.unreadCount - 1} more
+                            </span>
+                        )}
+                    </p>
+                    <p className={styles.previewName}>
+                        from{" "}
+                        <span className={styles.tealText}>
+                            {preview.friendName}
+                        </span>
+                    </p>
+                </div>
+            ))}
             <button
                 className={styles.navButton}
                 onClick={() => navigate("/messages")}>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -143,27 +143,30 @@ const Dashboard = () => {
     const messagesSection = (
         <div className={styles.messagesContainer}>
             <h2 className={styles.sectionHeader}>Messages</h2>
-            {unreadMessages.map((preview) => (
-                <div
-                    key={preview.friendId}
-                    className={styles.messagesPreview}>
-                    <p className={styles.previewText}>
-                        {preview.latestUnread}
-                        {preview.unreadCount > 1 && (
+            <div className={styles.previews}>
+                {unreadMessages.map((preview) => (
+                    <div
+                        key={preview.friendId}
+                        className={styles.messagesPreview}>
+                        <p className={styles.previewText}>
+                            {preview.latestUnread}
+                            {preview.unreadCount > 1 && (
+                                <span className={styles.tealText}>
+                                    {" "}
+                                    and {preview.unreadCount - 1} more
+                                </span>
+                            )}
+                        </p>
+                        <p className={styles.previewName}>
+                            from{" "}
                             <span className={styles.tealText}>
-                                {" "}
-                                and {preview.unreadCount - 1} more
+                                {preview.friendName}
                             </span>
-                        )}
-                    </p>
-                    <p className={styles.previewName}>
-                        from{" "}
-                        <span className={styles.tealText}>
-                            {preview.friendName}
-                        </span>
-                    </p>
-                </div>
-            ))}
+                        </p>
+                    </div>
+                ))}
+            </div>
+
             <button
                 className={styles.navButton}
                 onClick={() => navigate("/messages")}>

--- a/frontend/src/components/Messages.tsx
+++ b/frontend/src/components/Messages.tsx
@@ -67,6 +67,8 @@ const Messages = () => {
         getMessagesBetween(id, cursor).then((data) => {
             if (data.length < MESSAGES_PER_PAGE) {
                 setMoreMessages(false);
+            } else {
+                setMoreMessages(true);
             }
             if (cursor === -1) {
                 setMessages(data);
@@ -87,11 +89,17 @@ const Messages = () => {
             } else {
                 // otherwise, find the newest message that is a duplicate of a message already on the display
                 const firstMatchIndex = newest.findIndex(
-                    (message) => message.id === current[0].id,
+                    (message: Message) => message.id === current[0].id,
                 );
 
                 // add only new messages
-                return [...newest.slice(0, firstMatchIndex), ...current];
+                return [
+                    ...newest.slice(
+                        0,
+                        firstMatchIndex === -1 ? undefined : firstMatchIndex,
+                    ),
+                    ...current,
+                ];
             }
         });
     };
@@ -107,7 +115,7 @@ const Messages = () => {
                 setAlertText("Failed to send message. Please try again.");
             } else {
                 // if message successfully sent, update display and clear input
-                setMessages((current) => [result, ...current]);
+                setMessages((current: Message[]) => [result, ...current]);
                 setNewMessage("");
             }
         }
@@ -123,6 +131,7 @@ const Messages = () => {
         }
     };
 
+    // check for enter presses in new message text box
     const handleInputKeyDown = (event: React.KeyboardEvent) => {
         if (event.key === "Enter") {
             handleSendClick();
@@ -138,7 +147,6 @@ const Messages = () => {
     useEffect(() => {
         if (selectedFriendId) {
             loadMessagesBetween(selectedFriendId, -1);
-            setMoreMessages(true);
 
             // every interval, load newly sent messages
             const interval = setInterval(() => {
@@ -154,8 +162,9 @@ const Messages = () => {
     // side menu with list of friends to select from
     const sideMenu = (
         <div className={styles.friendsContainer}>
-            {friends.map((friend) => (
+            {friends.map((friend: AllUserData) => (
                 <div
+                    key={friend.id}
                     className={`${styles.friend} ${friend.id === selectedFriendId ? styles.selected : ""}`}
                     onClick={() => {
                         setSelectedFriendId(friend.id);

--- a/frontend/src/components/Messages.tsx
+++ b/frontend/src/components/Messages.tsx
@@ -107,7 +107,7 @@ const Messages = () => {
                 newMessage,
             );
             if (!success) {
-                setAlertText("Something went wrong.");
+                setAlertText("Failed to send message. Please try again.");
             } else {
                 // if message successfully sent, update display and clear input
                 setMessages((current) => [result, ...current]);

--- a/frontend/src/components/Messages.tsx
+++ b/frontend/src/components/Messages.tsx
@@ -7,7 +7,7 @@ import {
     faArrowRight,
 } from "@fortawesome/free-solid-svg-icons";
 import { useNavigate } from "react-router-dom";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { AllUserData, Message } from "../types";
 import { getAllData, getMessagesBetween, sendMessage } from "../utils";
 import Alert from "./Alert";
@@ -21,9 +21,6 @@ import Modal from "./Modal";
 const Messages = () => {
     // the logged-in user
     const { user } = useUser();
-
-    // reference to new message text box
-    const inputRef = useRef<HTMLInputElement | null>(null);
 
     const navigate = useNavigate();
 
@@ -101,7 +98,7 @@ const Messages = () => {
 
     // send a message with entered text to the selected user
     const handleSendClick = async () => {
-        if (newMessage && selectedFriendId) {
+        if (newMessage.trim() && selectedFriendId) {
             const [success, result] = await sendMessage(
                 selectedFriendId,
                 newMessage,
@@ -111,9 +108,7 @@ const Messages = () => {
             } else {
                 // if message successfully sent, update display and clear input
                 setMessages((current) => [result, ...current]);
-                if (inputRef.current) {
-                    inputRef.current.value = "";
-                }
+                setNewMessage("");
             }
         }
     };
@@ -125,6 +120,12 @@ const Messages = () => {
                 selectedFriendId,
                 messages[messages.length - 1].id,
             );
+        }
+    };
+
+    const handleInputKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === "Enter") {
+            handleSendClick();
         }
     };
 
@@ -218,13 +219,15 @@ const Messages = () => {
                 type="text"
                 className={styles.input}
                 placeholder="New message"
-                ref={inputRef}
+                value={newMessage}
+                onKeyDown={handleInputKeyDown}
                 onChange={(event) => {
                     setNewMessage(event.target.value);
                 }}></input>
             <button
                 className={styles.sendButton}
-                onClick={handleSendClick}>
+                onClick={handleSendClick}
+                disabled={!newMessage.trim()}>
                 <FontAwesomeIcon
                     icon={faArrowRight}
                     color="white"

--- a/frontend/src/components/Messages.tsx
+++ b/frontend/src/components/Messages.tsx
@@ -176,7 +176,29 @@ const Messages = () => {
                 <div
                     key={message.id}
                     className={`${styles.message} ${message.fromUser === user!.id ? styles.fromMe : styles.fromOther}`}>
-                    {message.text}
+                    <div className={styles.messageTime}>
+                        <p>
+                            {new Date(message.timestamp).toLocaleDateString(
+                                "en-US",
+                                {
+                                    month: "short",
+                                    day: "numeric",
+                                    year: "numeric",
+                                },
+                            )}
+                        </p>
+                        <p>
+                            {new Date(message.timestamp).toLocaleTimeString(
+                                "en-US",
+                                {
+                                    hour12: true,
+                                    hour: "numeric",
+                                    minute: "numeric",
+                                },
+                            )}
+                        </p>
+                    </div>
+                    <div className={styles.messageText}>{message.text}</div>
                 </div>
             ))}
             {moreMessages && (

--- a/frontend/src/css/Dashboard.module.css
+++ b/frontend/src/css/Dashboard.module.css
@@ -89,6 +89,28 @@
     gap: 1rem;
 }
 
+.messagesPreview {
+    width: 100%;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    background-color: var(--tan-background);
+    border-radius: 2rem;
+}
+
+.previewText {
+    margin: 0 0 1rem;
+    font-size: 18px;
+}
+
+.previewName {
+    margin: 0;
+    font-size: 18px;
+}
+
+.tealText {
+    color: var(--teal-accent);
+}
+
 .navButton {
     background-color: var(--tan-background);
     border: none;

--- a/frontend/src/css/Dashboard.module.css
+++ b/frontend/src/css/Dashboard.module.css
@@ -4,6 +4,7 @@
     height: 100vh;
     padding: 1rem;
     box-sizing: border-box;
+    overflow: hidden;
 }
 
 .titleContainer {
@@ -86,6 +87,16 @@
     flex-flow: column nowrap;
     grid-column: 1 / 2;
     width: 30vw;
+    gap: 1rem;
+}
+
+.previews {
+    width: 100%;
+    height: stretch;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    display: flex;
+    flex-flow: column nowrap;
     gap: 1rem;
 }
 

--- a/frontend/src/css/Messages.module.css
+++ b/frontend/src/css/Messages.module.css
@@ -57,7 +57,7 @@
 }
 
 .selected {
-    border: var(--teal-accent) 2px solid;
+    outline: var(--teal-accent) 2px solid;
 }
 
 .rightBox {

--- a/frontend/src/css/Messages.module.css
+++ b/frontend/src/css/Messages.module.css
@@ -75,7 +75,8 @@
 
 .messages {
     width: 100%;
-    overflow: scroll;
+    overflow-x: hidden;
+    overflow-y: scroll;
     display: flex;
     flex-flow: column-reverse nowrap;
     gap: 1rem;
@@ -85,22 +86,58 @@
 }
 
 .message {
-    padding: 1rem;
     box-sizing: border-box;
     width: fit-content;
-    max-width: 50%;
+    max-width: calc(50% + 6rem);
     font-size: 20px;
-    border-radius: 1rem;
+    display: flex;
+    gap: 0.5rem;
 }
 
 .fromMe {
     align-self: flex-end;
-    background-color: var(--light-teal-accent);
+    flex-flow: row-reverse nowrap;
 }
 
 .fromOther {
     align-self: flex-start;
+    flex-flow: row nowrap;
+}
+
+.messageText {
+    box-sizing: border-box;
+    padding: 1rem;
+    border-radius: 1rem;
+    max-width: calc(100% - 6.5rem);
+}
+
+.fromMe .messageText {
+    background-color: var(--light-teal-accent);
+}
+
+.fromOther .messageText {
     background-color: var(--tan-background);
+}
+
+.messageTime {
+    font-size: 16px;
+    width: 6rem;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    box-sizing: border-box;
+}
+
+.fromMe .messageTime {
+    align-items: flex-start;
+}
+
+.fromOther .messageTime {
+    align-items: flex-end;
+}
+
+.messageTime p {
+    margin: 0;
 }
 
 .inputContainer {

--- a/frontend/src/css/Messages.module.css
+++ b/frontend/src/css/Messages.module.css
@@ -174,6 +174,11 @@
     border-radius: 100%;
 }
 
+.sendButton:disabled {
+    background-color: var(--light-teal-accent);
+    cursor: not-allowed;
+}
+
 .loadButton {
     font-family: inherit;
     font-size: 20px;

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -137,3 +137,10 @@ export interface ClusterData {
     geohash: string;
     userIds: number[];
 }
+
+export interface MessagesPreview {
+    friendId: number;
+    friendName: string;
+    unreadCount: number;
+    latestUnread: string;
+}

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -6,6 +6,7 @@ import type {
     Message,
     UserGeohash,
     ClusterData,
+    MessagesPreview,
 } from "./types";
 import { GEOHASH_RADII } from "./constants";
 import { areHashesClose } from "./recommendation-utils";
@@ -432,6 +433,39 @@ export const findClusters = (userData: UserGeohash[]) => {
             result.push({
                 geohash: user.geohash,
                 userIds: [user.userId],
+            });
+        }
+    }
+
+    return result;
+};
+
+/**
+ *
+ * @param id the id of the current user
+ * @returns an array of data on friends who have sent the user unread messages
+ */
+export const getMessagesPreviews = async (id: number) => {
+    const { friends } = await getAllData(id);
+
+    const result = Array() as MessagesPreview[];
+
+    for (const friend of friends) {
+        const response = await fetch(
+            `${import.meta.env.VITE_SERVER_URL}/unreadMessages/${friend}`,
+            {
+                credentials: "include",
+            },
+        );
+
+        const unreads = await response.json();
+
+        if (unreads.unreadCount > 0) {
+            const { firstName, lastName } = await getAllData(friend);
+            result.push({
+                friendId: friend,
+                friendName: firstName + " " + lastName,
+                ...unreads,
             });
         }
     }


### PR DESCRIPTION
## Description
- Utilize `read` field to show unread messages on the dashboard
- Show the timestamp of each message on the display
- Pressing enter while in the new message text box will now send the message (if it is not empty)
- Implement feedback from #22 on type annotations and error messages
### Future work
- The problem of handling more than 10 new messages sent within 3 seconds proved more complex than I thought, and I think that will be a stretch improvement I focus on after TCs and other priority features.

## Milestones
- Works towards #36 

## Resources
[JS Date locale options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#locale_options)

## Test Plan
[Loom video](https://www.loom.com/share/afdaa99959fc41358df201b99a4a4f15?sid=7ba88823-97df-4e86-8543-82e1b287a8eb)
When I send a message to another user, it will appear the next time they reload the dashboard and remain there until they read the message. The send button is also disabled while the new message text box is empty.
