### PR TITLE
Like place recommendations and infer weight adjustments

### DIFF
--- a/backend/prisma/migrations/20250715203459_init_weights_table/migration.sql
+++ b/backend/prisma/migrations/20250715203459_init_weights_table/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "PlaceRecommendationWeights" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "friendWeight" DECIMAL(65,30) NOT NULL DEFAULT 1,
+    "pastVisitWeight" DECIMAL(65,30) NOT NULL DEFAULT 1,
+    "countWeight" DECIMAL(65,30) NOT NULL DEFAULT 1,
+    "similarityWeight" DECIMAL(65,30) NOT NULL DEFAULT 1,
+    "distanceWeight" DECIMAL(65,30) NOT NULL DEFAULT 1,
+
+    CONSTRAINT "PlaceRecommendationWeights_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlaceRecommendationWeights_userId_key" ON "PlaceRecommendationWeights"("userId");

--- a/backend/prisma/migrations/20250716174932_add_type/migration.sql
+++ b/backend/prisma/migrations/20250716174932_add_type/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "PlaceRecommendationWeights" ADD COLUMN     "likedTypes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "typeWeight" DECIMAL(65,30) NOT NULL DEFAULT 1;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -65,3 +65,13 @@ model Session {
   data String
   expiresAt DateTime
 }
+
+model PlaceRecommendationWeights {
+  id Int @id @default(autoincrement())
+  userId Int @unique
+  friendWeight Decimal @default(1)
+  pastVisitWeight Decimal @default(1)
+  countWeight Decimal @default(1)
+  similarityWeight Decimal @default(1)
+  distanceWeight Decimal @default(1)
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -74,4 +74,6 @@ model PlaceRecommendationWeights {
   countWeight Decimal @default(1)
   similarityWeight Decimal @default(1)
   distanceWeight Decimal @default(1)
+  typeWeight Decimal @default(1)
+  likedTypes String[] @default([])
 }

--- a/frontend/src/components/RecommendationList.tsx
+++ b/frontend/src/components/RecommendationList.tsx
@@ -4,6 +4,7 @@ import {
     getNearbyPOIs,
     updateWeights,
     areHashesClose,
+    getAdjustment,
 } from "../recommendation-utils";
 import { useState, useRef } from "react";
 import type {
@@ -23,11 +24,6 @@ import {
     faThumbsUp,
     faUsers,
 } from "@fortawesome/free-solid-svg-icons";
-import {
-    DELTA,
-    LIKED_WEIGHT_DECREASE,
-    LIKED_WEIGHT_INCREASE,
-} from "../constants";
 
 interface RecommendationListProps {
     myLocation: string;
@@ -52,10 +48,12 @@ const RecommendationList = ({
     // the myLocation value last used to calculate nearbyPlaces
     const lastLocation = useRef("");
 
+    // averages for some place data values; compared against liked places' values to determine how to adjust weights
     const [placesStats, setPlacesStats] = useState<PlaceRecStats | null>(null);
 
     const [loading, setLoading] = useState(false);
 
+    // load places, compile relevant data on them, and sort them by recommendation score
     const loadPlaces = async () => {
         setLoading(true);
 
@@ -115,17 +113,6 @@ const RecommendationList = ({
                     place.geohashDistance,
                 ),
             }).then(loadPlaces);
-        }
-    };
-
-    // calculate how to adjust a weight by comparing a place's value to the overall average
-    const getAdjustment = (average: number, value: number) => {
-        if (Math.abs(value - average) < DELTA) {
-            return 0;
-        } else if (value < average) {
-            return LIKED_WEIGHT_DECREASE;
-        } else {
-            return LIKED_WEIGHT_INCREASE;
         }
     };
 

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -59,31 +59,6 @@ export const NEARBY_PLACES_RADIUS = 5000;
 export const MAX_PLACE_RESULTS = 10;
 
 /**
- * Weight of average present user similarity in place recommendation algorithm
- */
-export const SIMILARITY_WEIGHT = 1;
-
-/**
- * Weight of present user count in place recommendation algorithm
- */
-export const COUNT_WEIGHT = 1;
-
-/**
- * Weight of present friend count in place recommendation algorithm
- */
-export const FRIEND_COUNT_WEIGHT = 1;
-
-/**
- * Weight of distance in place recommendation algorithm
- */
-export const DISTANCE_WEIGHT = 1;
-
-/**
- * Weight of number of past visits to the place in place recommendation algorithm
- */
-export const PAST_WEIGHT = 1;
-
-/**
  * Number of messages returned from each query
  */
 export const MESSAGES_PER_PAGE = 10;
@@ -102,3 +77,9 @@ export const MS_IN_DAY = 24 * 60 * 60 * 1000;
  * The number of milliseconds in a minute
  */
 export const MS_IN_MINUTE = 60 * 1000;
+
+export const DELTA = 1e-4;
+
+export const LIKED_WEIGHT_INCREASE = 0.5;
+
+export const LIKED_WEIGHT_DECREASE = -0.5;

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -78,8 +78,17 @@ export const MS_IN_DAY = 24 * 60 * 60 * 1000;
  */
 export const MS_IN_MINUTE = 60 * 1000;
 
+/**
+ * The margin of error allowed when determining whether two decimals are approximately equal
+ */
 export const DELTA = 1e-4;
 
+/**
+ * The amount by which to increase the weight of a value that a liked place is above average in
+ */
 export const LIKED_WEIGHT_INCREASE = 0.5;
 
+/**
+ * The negative amount by which to decrease the weight of a value that a liked place is below average in
+ */
 export const LIKED_WEIGHT_DECREASE = -0.5;

--- a/frontend/src/css/RecommendationList.module.css
+++ b/frontend/src/css/RecommendationList.module.css
@@ -38,12 +38,32 @@
     width: 100%;
 }
 
+.nameContainer {
+    display: flex;
+    flex-flow: row nowrap;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0.5rem 0 0.25rem;
+    gap: 0.25rem;
+}
+
 .placeName {
     font-size: 18px;
-    margin: 0.5rem 0 0.25rem;
+    margin: 0;
 }
 
 .placeAddress {
+    font-size: 16px;
+}
+
+.likeButton {
+    background-color: var(--teal-accent);
+    color: white;
+    border: none;
+    padding: 0.75rem 0.8rem;
+    box-sizing: border-box;
+    border-radius: 100%;
     font-size: 16px;
 }
 

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -122,9 +122,22 @@ export interface PlaceRecUserData {
  * certain factors in a place's recommendation score
  */
 export interface WeightAdjustments {
-    distance: number;
-    numUsers: number;
-    pastVisits: number;
+    friendAdjustment?: number;
+    pastVisitAdjustment?: number;
+    countAdjustment?: number;
+    similarityAdjustment?: number;
+    distanceAdjustment?: number;
+}
+
+/**
+ * Represents the weights saved for a user for use in calculating their recommended places
+ */
+export interface Weights {
+    friendWeight: number;
+    pastVisitWeight: number;
+    countWeight: number;
+    similarityWeight: number;
+    distanceWeight: number;
 }
 
 export interface FriendRequest {

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -129,6 +129,14 @@ export interface WeightAdjustments {
     distanceAdjustment?: number;
 }
 
+export interface PlaceRecStats {
+    avgFriendCount: number;
+    avgVisitScore: number;
+    avgCount: number;
+    avgUserSimilarity: number;
+    avgDistance: number;
+}
+
 /**
  * Represents the weights saved for a user for use in calculating their recommended places
  */

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -68,6 +68,7 @@ export interface Place {
         latitude: number;
         longitude: number;
     };
+    primaryType: string;
 }
 
 /**
@@ -90,6 +91,7 @@ export interface PlaceHistory {
  * @property numVisits the number of times the user has visited this place in the past
  * @property visitScore a weighted score based on the recency and duration of past visits;
  * increases with higher relevance to the user
+ * @property isLikedType true if the place's primary type is one the user has liked in the past
  * @property userData holds information on the number of other users at this place
  * @property score the final weighted score combining all of this information
  */
@@ -99,6 +101,7 @@ export interface PlaceRecData {
     geohashDistance: number;
     numVisits: number;
     visitScore: number;
+    isLikedType: boolean;
     userData: {
         count: number;
         avgInterestAngle: number;
@@ -127,6 +130,7 @@ export interface WeightAdjustments {
     countAdjustment?: number;
     similarityAdjustment?: number;
     distanceAdjustment?: number;
+    typeAdjustment?: number;
 }
 
 /**
@@ -141,7 +145,7 @@ export interface PlaceRecStats {
 }
 
 /**
- * Represents the weights saved for a user for use in calculating their recommended places
+ * Represents the weights and liked place types saved for a user for use in calculating their recommended places
  */
 export interface Weights {
     friendWeight: number;
@@ -149,6 +153,8 @@ export interface Weights {
     countWeight: number;
     similarityWeight: number;
     distanceWeight: number;
+    typeWeight: number;
+    likedTypes: string[];
 }
 
 export interface FriendRequest {

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -83,15 +83,15 @@ export interface PlaceHistory {
 
 /**
  * Represents data on a place and the users at that place in relation to the current user
- *
- * geohashDistance is the resolution up to which this place and the current user are in the same hash box:
- * as it increases, the place is closer
- *
- * visitScore increases with the recency and duration of the user's past visits to the place
- *
- * userData contains information about users found to be at the place:
- * count is the number of users, avgInterestAngle is inversely related to their average similarity to the current user,
- * and friendCount is the number of friends at the place
+ * @property place the place itself as returned from the Places API
+ * @property geohash the place's location
+ * @property geohashDistance the number of characters this place's geohash has in common with the current user's;
+ * increases with closeness to the user
+ * @property numVisits the number of times the user has visited this place in the past
+ * @property visitScore a weighted score based on the recency and duration of past visits;
+ * increases with higher relevance to the user
+ * @property userData holds information on the number of other users at this place
+ * @property score the final weighted score combining all of this information
  */
 export interface PlaceRecData {
     place: Place;
@@ -129,6 +129,9 @@ export interface WeightAdjustments {
     distanceAdjustment?: number;
 }
 
+/**
+ * The average values of certain place recommendation factors for a list of nearby places
+ */
 export interface PlaceRecStats {
     avgFriendCount: number;
     avgVisitScore: number;


### PR DESCRIPTION
## Description
- Store each user's adjusted weights in the database so they persist across page loads 
- Allow the user to like each recommended place; then, increase their weight for factors that place was above average in, and decrease for below average
- Fetch the primary type of each place; if the user likes a place, save that type to the database and use whether or not a place's type has been liked as another recommendation factor
- Decrease load time by only refetching nearby places from the Google Maps API if the user has moved
### Future work
- Since weights are increased/decreased by static values, the impact of liking a place high in one factor decreases as the weight for that factor grows. This could be desired, or I could explore scaling up the weight instead.
- I could fetch all of a place's types and check for any matches with the liked types; I was concerned about the time complexity of comparing arrays of types against each other, instead of checking whether the liked types array contains a single primary type as I do now.
- I read the feedback on letting the user directly change all the factors in the feedback drawer. I held off on changing that because I wonder if I should keep those buttons now that the like buttons are present; are there now too many actions being presented to the user in this small sidebar?

## Milestones
- Improves UX and efficiency of TC 2

## Resources
[Google Maps Places API Place Types](https://developers.google.com/maps/documentation/places/web-service/place-types)

## Test Plan
[Loom video](https://www.loom.com/share/49c55765a3284291ab5f177d7c279b4a?sid=089666bc-7840-4fe0-b4aa-5cdd0b0c312d)
When I like the hotel that has an above-average past visit score, it goes to the top of the list and the other hotel gets a boost as well, since they share a type. You can also see that subsequent loads are faster than the initial one, since I'm not making another request to the Google Maps API. 