### PR TITLE
Write tests for Edit Profile page and fix earlier tests

### DIFF
--- a/frontend/tests/Dashboard.test.tsx
+++ b/frontend/tests/Dashboard.test.tsx
@@ -175,24 +175,26 @@ describe("Dashboard", () => {
         expect(getMessagesPreviews).toHaveBeenCalledOnce();
     });
 
-    it("renders friend requests", () => {
+    it("renders friend requests", async () => {
         render(<Dashboard></Dashboard>);
 
         // should call getAllData() and show request from mocked name
-        waitFor(() => {
-            screen.getByText(/^From Test Requester$/);
+        await waitFor(() => {
+            screen.getByText(/^From$/);
+            screen.getByText(/^Test Requester$/);
             screen.getByText(/^Accept$/);
             screen.getByText(/^Decline$/);
         });
     });
 
-    it("renders unread messages", () => {
+    it("renders unread messages", async () => {
         render(<Dashboard></Dashboard>);
 
         // should show message text and sender
-        waitFor(() => {
+        await waitFor(() => {
             screen.getByText(/^Hello!$/);
-            screen.getByText(/^from Test Friend$/);
+            screen.getByText(/^from$/);
+            screen.getByText(/^Test Friend$/);
         });
     });
 });

--- a/frontend/tests/EditProfile.test.tsx
+++ b/frontend/tests/EditProfile.test.tsx
@@ -1,19 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { SavedUser, UserProfile } from "../src/types";
 import EditProfile from "../src/components/EditProfile";
-import { updateProfile } from "../src/utils";
+import { getInterestName, getProfile, updateProfile } from "../src/utils";
 
 // mock utils to prevent backend fetches and get call data
 vi.mock("../src/utils", async (importOriginal) => {
     return {
         ...(await importOriginal<typeof import("../src/utils")>()),
         getProfile: vi.fn(
-            async (id: number): Promise<UserProfile> =>
+            async (id: number): Promise<UserProfile | null> =>
                 await Promise.resolve({
                     firstName: "Test",
                     lastName: "Profile",
-                    interests: [0, 1, 1, 0, 0, 0],
+                    interests: [0, 0, 0, 0, 0, 0],
                 }),
         ),
         updateProfile: vi.fn(
@@ -45,6 +45,10 @@ vi.mock("../src/contexts/UserContext", async (importOriginal) => {
 });
 
 describe("Edit Profile", () => {
+    afterEach(() => vi.clearAllMocks());
+
+    afterAll(() => vi.restoreAllMocks());
+
     it("renders the form", () => {
         render(<EditProfile></EditProfile>);
 
@@ -59,6 +63,9 @@ describe("Edit Profile", () => {
 
         // check for submit button
         screen.getByText(/^Save$/);
+
+        // should call getProfile to populate form
+        expect(getProfile).toHaveBeenCalledOnce();
     });
 
     it("submits the form", async () => {
@@ -74,6 +81,73 @@ describe("Edit Profile", () => {
         // success alert should show
         await waitFor(() => {
             screen.getByText(/^Successfully updated profile\.$/);
+        });
+    });
+
+    it("submits with user input", async () => {
+        render(<EditProfile></EditProfile>);
+
+        const testInputs = {
+            firstName: "Test",
+            lastName: "Edit",
+            interests: [0, 0, 0, 0, 0, 0],
+            bio: "editing",
+        };
+
+        // wait for form to populate, then change last name and add bio
+        const lastName = await waitFor(() => {
+            const element = screen.getByLabelText(/^Last name$/);
+            return element;
+        });
+
+        const bio = await waitFor(() => {
+            const element = screen.getByLabelText(/^Bio$/);
+            return element;
+        });
+
+        fireEvent.change(lastName, { target: { value: testInputs.lastName } });
+        fireEvent.change(bio, { target: { value: testInputs.bio } });
+
+        // click "Save" button
+        const submitButton = screen.getByText(/^Save$/);
+        fireEvent.click(submitButton);
+
+        // wait for updateProfile to be called
+        await waitFor(() => {
+            expect(updateProfile).toHaveBeenCalledExactlyOnceWith(testInputs);
+        });
+    });
+
+    it("submits with updated interests", async () => {
+        render(<EditProfile></EditProfile>);
+
+        const testInputs = {
+            firstName: "Test",
+            lastName: "Profile",
+            interests: [0, 1, 1, 0, 0, 0],
+        };
+
+        // wait for form to populate, then select interests at indices 1 and 2
+        const interest1 = await waitFor(() => {
+            const element = screen.getByText(getInterestName(1));
+            return element;
+        });
+
+        const interest2 = await waitFor(() => {
+            const element = screen.getByText(getInterestName(2));
+            return element;
+        });
+
+        fireEvent.click(interest1);
+        fireEvent.click(interest2);
+
+        // click "Save" button
+        const submitButton = screen.getByText(/^Save$/);
+        fireEvent.click(submitButton);
+
+        // wait for updateProfile to be called
+        await waitFor(() => {
+            expect(updateProfile).toHaveBeenCalledExactlyOnceWith(testInputs);
         });
     });
 });

--- a/frontend/tests/EditProfile.test.tsx
+++ b/frontend/tests/EditProfile.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SavedUser, UserProfile } from "../src/types";
+import EditProfile from "../src/components/EditProfile";
+import { updateProfile } from "../src/utils";
+
+// mock utils to prevent backend fetches and get call data
+vi.mock("../src/utils", async (importOriginal) => {
+    return {
+        ...(await importOriginal<typeof import("../src/utils")>()),
+        getProfile: vi.fn(
+            async (id: number): Promise<UserProfile> =>
+                await Promise.resolve({
+                    firstName: "Test",
+                    lastName: "Profile",
+                    interests: [0, 1, 1, 0, 0, 0],
+                }),
+        ),
+        updateProfile: vi.fn(
+            async (data: UserProfile) => await Promise.resolve(true),
+        ),
+    };
+});
+
+const mockNavigate = vi.fn((path: string) => {});
+
+// mock useNavigate to get navigate's call data
+vi.mock("react-router-dom", async (importOriginal) => {
+    return {
+        ...(await importOriginal<typeof import("react-router-dom")>()),
+        useNavigate: () => mockNavigate,
+    };
+});
+
+// mock useUser to pretend the user is authenticated
+vi.mock("../src/contexts/UserContext", async (importOriginal) => {
+    return {
+        ...(await importOriginal<
+            typeof import("../src/contexts/UserContext")
+        >()),
+        useUser: vi.fn((): { user: SavedUser | null } => {
+            return { user: { id: 1, email: "test@test.com" } };
+        }),
+    };
+});
+
+describe("Edit Profile", () => {
+    it("renders the form", () => {
+        render(<EditProfile></EditProfile>);
+
+        // check for form inputs
+        screen.getByLabelText(/^First name$/);
+        screen.getByLabelText(/^Last name$/);
+        screen.getByLabelText(/^Pronouns$/);
+        screen.getByLabelText(/^Age$/);
+        screen.getByLabelText(/^Major$/);
+        screen.getByText(/^Interests$/);
+        screen.getByLabelText(/^Bio$/);
+
+        // check for submit button
+        screen.getByText(/^Save$/);
+    });
+
+    it("submits the form", async () => {
+        render(<EditProfile></EditProfile>);
+
+        // click "Save" button
+        const submitButton = screen.getByText(/^Save$/);
+        fireEvent.click(submitButton);
+
+        // updateProfile should be called
+        expect(updateProfile).toHaveBeenCalledOnce();
+
+        // success alert should show
+        await waitFor(() => {
+            screen.getByText(/^Successfully updated profile\.$/);
+        });
+    });
+});

--- a/frontend/tests/LoginForm.test.tsx
+++ b/frontend/tests/LoginForm.test.tsx
@@ -109,12 +109,8 @@ describe("Login page", () => {
         expect(mockNavigate).toHaveBeenCalledExactlyOnceWith("/signup");
     });
 
-    it("shows error alert", () => {
+    it("shows error alert", async () => {
         render(<LoginForm></LoginForm>);
-
-        // click on "Login" button
-        const submitButton = screen.getByText(/^Login$/);
-        fireEvent.click(submitButton);
 
         const testErrorMessage = "Error";
 
@@ -125,11 +121,15 @@ describe("Login page", () => {
             { error: testErrorMessage },
         ]);
 
+        // click on "Login" button
+        const submitButton = screen.getByText(/^Login$/);
+        fireEvent.click(submitButton);
+
         // login should be called
         expect(login).toHaveBeenCalledOnce();
 
         // alert should show once login completes
-        waitFor(() => {
+        await waitFor(() => {
             screen.getByText(testErrorMessage);
         });
     });

--- a/frontend/tests/SignupForm.test.tsx
+++ b/frontend/tests/SignupForm.test.tsx
@@ -125,12 +125,8 @@ describe("Create account page", () => {
         expect(mockNavigate).toHaveBeenCalledExactlyOnceWith("/login");
     });
 
-    it("shows error alert", () => {
+    it("shows error alert", async () => {
         render(<SignupForm></SignupForm>);
-
-        // click on "Create account" button
-        const submitButton = screen.getByText(/^Create Account$/);
-        fireEvent.click(submitButton);
 
         const testErrorMessage = "Error";
 
@@ -138,11 +134,15 @@ describe("Create account page", () => {
         // @ts-ignore since TS doesn't recognize createAccount as a mock
         createAccount.mockImplementationOnce(() => [false, testErrorMessage]);
 
+        // click on "Create account" button
+        const submitButton = screen.getByText(/^Create Account$/);
+        fireEvent.click(submitButton);
+
         // createAccount should be called
         expect(createAccount).toHaveBeenCalledOnce();
 
         // alert should show once createAccount completes
-        waitFor(() => {
+        await waitFor(() => {
             screen.getByText(testErrorMessage);
         });
     });


### PR DESCRIPTION
## Description
- Write unit tests for EditProfile.tsx
- Add `await` in front of `waitFor()` calls to ensure tests don't skip checks in the callback and pass when they shouldn't
- Now that tests work correctly, ensure `mockImplementationOnce()` is called before the button click that calls the mocked function
- Also split up text checks for text that is split between DOM elements

## Milestones
- Completes Edit Profile testing as outlined in the [Test Plan](https://docs.google.com/document/d/1znM1YONi839q-lXX20BUmhVXxjvx2G_n6QIf-4U0Lmk/edit?usp=sharing)

## Resources
[Vitest waitFor()](https://vitest.dev/api/vi.html#vi-waitfor)