### PR TITLE
Refine UX on People You May Know page

### DIFF
--- a/frontend/src/components/People.tsx
+++ b/frontend/src/components/People.tsx
@@ -70,10 +70,14 @@ const People = () => {
     };
 
     // when profile button is clicked, try to send friend request
-    const handleFriendClick = async (id: number) => {
+    const handleFriendClick = async (id: number, event: React.MouseEvent) => {
         const success = await sendFriendRequest(id);
-        setAlertText(getFriendRequestAlert(success));
+        setAlertText(
+            `${getFriendRequestAlert(success)} Try sending a request to their friends as well!`,
+        );
         boostConnectionsOf(id);
+        // @ts-ignore
+        event.target.disabled = true;
     };
 
     // when profile button is clicked, block user and reload suggestions

--- a/frontend/src/components/People.tsx
+++ b/frontend/src/components/People.tsx
@@ -42,6 +42,9 @@ const People = () => {
     // users at some degree of separation from the current user
     const [suggestions, setSuggestions] = useState<SuggestedProfile[]>([]);
 
+    // whether the loading bar is showing
+    const [loading, setLoading] = useState(true);
+
     // text shown in alert; null when alert is not showing
     const [alertText, setAlertText] = useState<string | null>(null);
 
@@ -78,6 +81,34 @@ const People = () => {
         const success = await blockUser(id);
         loadSuggestedPeople();
         setAlertText(getBlockAlert(success));
+    };
+
+    // load data on people suggestions either from database or cache
+    const loadSuggestedPeople = async () => {
+        if (!user) {
+            return;
+        }
+
+        setLoading(true);
+
+        const updatedCache = await updateCache();
+
+        // once cache has been checked/updated, load suggestions display from cache if necessary
+        if (updatedCache) {
+            const newSuggestions: SuggestedProfile[] = [];
+            for (const cacheValue of updatedCache.values()) {
+                const friendPath = findFriendPath(updatedCache, cacheValue);
+
+                newSuggestions.push({
+                    data: cacheValue.data,
+                    degree: cacheValue.degree,
+                    friendPath: friendPath,
+                });
+            }
+            setSuggestions(newSuggestions);
+        }
+
+        setLoading(false);
     };
 
     // check validity of cache and return a reference to the updated cache that should be used for loading
@@ -148,44 +179,20 @@ const People = () => {
         return updatedCache;
     };
 
-    // load data on people suggestions either from database or cache
-    const loadSuggestedPeople = async () => {
-        if (!user) {
-            return;
-        }
-
-        const updatedCache = await updateCache();
-
-        // once cache has been checked/updated, load suggestions display from cache if necessary
-        if (updatedCache) {
-            const newSuggestions: SuggestedProfile[] = [];
-            for (const cacheValue of updatedCache.values()) {
-                const friendPath = findFriendPath(updatedCache, cacheValue);
-
-                newSuggestions.push({
-                    data: cacheValue.data,
-                    degree: cacheValue.degree,
-                    friendPath: friendPath,
-                });
-            }
-            setSuggestions(newSuggestions);
-        }
-    };
-
     // once logged-in user loads, load suggestions
     useEffect(() => {
         loadSuggestedPeople();
     }, [user]);
 
     // profile cards for each suggested user
-    const suggestedUsersDisplay =
-        suggestions.length === 0 ? (
-            <div className={styles.loadingContainer}>
-                <Loading></Loading>
-            </div>
-        ) : (
-            <>
-                {suggestions
+    const suggestedUsersDisplay = loading ? (
+        <div className={styles.loadingContainer}>
+            <Loading></Loading>
+        </div>
+    ) : (
+        <>
+            {suggestions.length > 0 ? (
+                suggestions
                     .sort((a, b) => a.degree - b.degree)
                     .map((user) => (
                         <PeopleCard
@@ -193,9 +200,14 @@ const People = () => {
                             user={user}
                             handleFriendClick={handleFriendClick}
                             handleBlockClick={handleBlockClick}></PeopleCard>
-                    ))}
-            </>
-        );
+                    ))
+            ) : (
+                <p className={styles.emptyMessage}>
+                    No suggestions to display.
+                </p>
+            )}
+        </>
+    );
 
     if (!user) {
         return <LoggedOut></LoggedOut>;

--- a/frontend/src/components/PeopleCard.tsx
+++ b/frontend/src/components/PeopleCard.tsx
@@ -6,7 +6,7 @@ import styles from "../css/PeopleCard.module.css";
 
 interface PeopleCardProps {
     user: SuggestedProfile;
-    handleFriendClick: (id: number) => void;
+    handleFriendClick: (id: number, event: React.MouseEvent) => void;
     handleBlockClick: (id: number) => void;
 }
 
@@ -54,7 +54,7 @@ const PeopleCard = ({
         <div className={styles.buttonsContainer}>
             <button
                 className={styles.button}
-                onClick={() => handleFriendClick(user.data.id)}>
+                onClick={(event) => handleFriendClick(user.data.id, event)}>
                 Send friend request
             </button>
             <button

--- a/frontend/src/css/People.module.css
+++ b/frontend/src/css/People.module.css
@@ -32,3 +32,9 @@
 .loadingContainer {
     grid-column: 1 / 4;
 }
+
+.emptyMessage {
+    grid-column: 1 / 4;
+    font-size: 24px;
+    text-align: center;
+}

--- a/frontend/src/css/PeopleCard.module.css
+++ b/frontend/src/css/PeopleCard.module.css
@@ -78,3 +78,15 @@
     background-color: var(--teal-accent);
     color: white;
 }
+
+.button:disabled {
+    border: var(--light-teal-accent) 2px solid;
+    color: var(--light-teal-accent);
+}
+
+.button:disabled:hover {
+    background-color: var(--light-teal-accent);
+    border: var(--light-teal-accent) 2px solid;
+    color: white;
+    cursor: not-allowed;
+}


### PR DESCRIPTION
## Description
- When the user sends a friend request to a suggested user, disable the friend request button and show a more informative alert to signal that that user's friends have been boosted in the sorting order
- Use a dedicated state variable for loading, instead of checking whether `suggestions` is empty
### Future work
- The disabled state of the button doesn't persist if you exit and enter the page again, as it's not saved in the cache. I could add `sentFriendRequest` as a field in the `CachedSuggestedProfile` interface and store this, but for this week I wanted to just implement what I can easily test.

## Milestones
- Closes #55 

## Resources
None

## Test Plan

https://github.com/user-attachments/assets/58149865-78d4-4003-816d-f9c59acdd7e6


