### PR TITLE
Change age to class year

### DIFF
--- a/backend/prisma/migrations/20250728161743_change_age_to_year/migration.sql
+++ b/backend/prisma/migrations/20250728161743_change_age_to_year/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `age` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "age",
+ADD COLUMN     "year" INTEGER;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,7 +21,7 @@ model User {
   firstName String
   lastName String
   pronouns String?
-  age Int?
+  year Int?
   major String?
   interests Int[]
   bio String?

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -18,7 +18,7 @@ router.get("/:id", async (req, res) => {
             firstName: true,
             lastName: true,
             pronouns: true,
-            age: true,
+            year: true,
             major: true,
             interests: true,
             bio: true,
@@ -39,19 +39,6 @@ router.get("/details/:id", async (req, res) => {
     const user = await prisma.user.findUnique({
         where: {
             id: userId,
-        },
-        select: {
-            id: true,
-            firstName: true,
-            lastName: true,
-            pronouns: true,
-            age: true,
-            major: true,
-            interests: true,
-            bio: true,
-            friends: true,
-            blockedUsers: true,
-            interests: true,
         },
     });
 

--- a/frontend/src/components/EditProfile.tsx
+++ b/frontend/src/components/EditProfile.tsx
@@ -26,7 +26,7 @@ const EditProfile = () => {
     const [formData, setFormData] = useState<UserProfile>({
         firstName: "",
         lastName: "",
-        interests: Array() as number[],
+        interests: [],
     });
 
     // update form data when value of any field changes
@@ -35,7 +35,7 @@ const EditProfile = () => {
     ) => {
         const { name, value } = event.target;
 
-        if (name === "age") {
+        if (name === "year") {
             setFormData({
                 ...formData,
                 [name]: parseInt(value),
@@ -112,13 +112,13 @@ const EditProfile = () => {
                     onChange={handleInputChange}></input>
             </label>
             <label className={`${styles.label} ${styles.lastHalf}`}>
-                Age
+                Graduation/class year
                 <input
                     className={styles.input}
-                    name="age"
+                    name="year"
                     type="number"
-                    placeholder="18"
-                    defaultValue={formData.age}
+                    placeholder="2028"
+                    defaultValue={formData.year}
                     onChange={handleInputChange}></input>
             </label>
             <label className={styles.label}>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -18,6 +18,7 @@ import {
     faArrowRight,
     faUserShield,
     faShieldHalved,
+    faCircle,
 } from "@fortawesome/free-solid-svg-icons";
 
 interface ModalProps {
@@ -236,6 +237,32 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
             </>
         );
 
+        const profileText = (
+            <>
+                <h2 className={styles.title}>
+                    {userData.firstName} {userData.lastName}{" "}
+                    <span className={styles.pronouns}>{userData.pronouns}</span>
+                </h2>
+                <div className={styles.academicInfo}>
+                    <p className={styles.major}>
+                        {userData.major ?? "(No major)"}
+                    </p>
+                    {userData.year ? (
+                        <>
+                            <FontAwesomeIcon
+                                icon={faCircle}
+                                size="2xs"></FontAwesomeIcon>
+                            <p className={styles.year}>
+                                Class of {userData.year}
+                            </p>
+                        </>
+                    ) : (
+                        <></>
+                    )}
+                </div>
+            </>
+        );
+
         return (
             <div
                 ref={overlayRef}
@@ -245,15 +272,7 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
                     alertText={alertText}
                     setAlertText={setAlertText}></Alert>
                 <div className={styles.modal}>
-                    <h2 className={styles.title}>
-                        {userData.firstName} {userData.lastName}{" "}
-                        <span className={styles.pronouns}>
-                            {userData.pronouns}
-                        </span>
-                    </h2>
-                    <p className={styles.major}>
-                        {userData.major ?? "(No major)"}
-                    </p>
+                    {profileText}
                     <div className={styles.interestsContainer}>
                         {userData.interests.map((value, index) => {
                             if (value === 1) {

--- a/frontend/src/components/PeopleCard.tsx
+++ b/frontend/src/components/PeopleCard.tsx
@@ -3,6 +3,8 @@ import type { SuggestedProfile } from "../types";
 import { getInterestName } from "../utils";
 import PeoplePath from "./PeoplePath";
 import styles from "../css/PeopleCard.module.css";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircle } from "@fortawesome/free-solid-svg-icons";
 
 interface PeopleCardProps {
     user: SuggestedProfile;
@@ -33,7 +35,19 @@ const PeopleCard = ({
             {user.data.firstName} {user.data.lastName}{" "}
             <span className={styles.pronouns}>{user.data.pronouns}</span>
         </h3>
-        <p className={styles.major}>{user.data.major ?? "(No major)"}</p>
+        <div className={styles.academicInfo}>
+            <p className={styles.major}>{user.data.major ?? "(No major)"}</p>
+            {user.data.year ? (
+                <>
+                    <FontAwesomeIcon
+                        icon={faCircle}
+                        size="2xs"></FontAwesomeIcon>
+                    <p className={styles.year}>Class of {user.data.year}</p>
+                </>
+            ) : (
+                <></>
+            )}
+        </div>
         <div className={styles.interestsContainer}>
             {user.data.interests.map((value: number, index) => {
                 if (value === 1) {

--- a/frontend/src/components/ProfilePopup.tsx
+++ b/frontend/src/components/ProfilePopup.tsx
@@ -2,6 +2,8 @@ import { Fragment } from "react";
 import styles from "../css/ProfilePopup.module.css";
 import type { AllUserData } from "../types";
 import { getInterestName } from "../utils";
+import { faCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 interface ProfilePopupProps {
     userData: AllUserData;
@@ -21,9 +23,23 @@ const ProfilePopup = ({ userData }: ProfilePopupProps) => {
                     {userData.pronouns}
                 </span>
             </h3>
-            <p className={styles.profileMajor}>
-                {userData.major ?? "(No major)"}
-            </p>
+            <div className={styles.academicInfo}>
+                <p className={styles.profileMajor}>
+                    {userData.major ?? "(No major)"}
+                </p>
+                {userData.year ? (
+                    <>
+                        <FontAwesomeIcon
+                            icon={faCircle}
+                            size="2xs"></FontAwesomeIcon>
+                        <p className={styles.profileYear}>
+                            Class of {userData.year}
+                        </p>
+                    </>
+                ) : (
+                    <></>
+                )}
+            </div>
             <div className={styles.interestsContainer}>
                 {userData.interests.map((value, index) => {
                     if (value === 1) {

--- a/frontend/src/css/Modal.module.css
+++ b/frontend/src/css/Modal.module.css
@@ -37,7 +37,16 @@
     margin: 0;
 }
 
-.major {
+.academicInfo {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.75rem;
+}
+
+.major,
+.year {
     font-size: 20px;
     margin: 0;
 }

--- a/frontend/src/css/PeopleCard.module.css
+++ b/frontend/src/css/PeopleCard.module.css
@@ -24,7 +24,16 @@
     font-weight: bold;
 }
 
-.major {
+.academicInfo {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+}
+
+.major,
+.year {
     margin: 0;
     font-size: 18px;
 }

--- a/frontend/src/css/ProfilePopup.module.css
+++ b/frontend/src/css/ProfilePopup.module.css
@@ -25,7 +25,16 @@
     margin: 0;
 }
 
-.profileMajor {
+.academicInfo {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.profileMajor,
+.profileYear {
     font-size: 16px;
     margin: 0;
 }

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -30,7 +30,7 @@ export interface UserProfile {
     firstName: string;
     lastName: string;
     pronouns?: string;
-    age?: number;
+    year?: number;
     major?: string;
     interests: number[];
     bio?: string;
@@ -44,7 +44,7 @@ export interface AllUserData {
     firstName: string;
     lastName: string;
     pronouns?: string;
-    age?: number;
+    year?: number;
     major?: string;
     interests: number[];
     bio?: string;

--- a/frontend/tests/EditProfile.test.tsx
+++ b/frontend/tests/EditProfile.test.tsx
@@ -56,7 +56,7 @@ describe("Edit Profile", () => {
         screen.getByLabelText(/^First name$/);
         screen.getByLabelText(/^Last name$/);
         screen.getByLabelText(/^Pronouns$/);
-        screen.getByLabelText(/^Age$/);
+        screen.getByLabelText(/^Graduation\/class year$/);
         screen.getByLabelText(/^Major$/);
         screen.getByText(/^Interests$/);
         screen.getByLabelText(/^Bio$/);


### PR DESCRIPTION
## Description
- Instead of the user's age, store their graduation year
- Update userRoutes.js to match schema (and remove redundant select clause for /user/details/:id)
- Update EditProfile.tsx and its tests to show a class year input instead of an age input
- Update all profile displays (i.e. Modal.tsx, ProfilePopup.tsx, and PeopleCard.tsx) to display class year if given

## Milestones
- Closes #46
- Improves UX: instead of asking for the user's age, which is not very relevant and was never displayed or used for any functionality, ask for their graduation year, which feels less invasive, matches well with the displayed major information, and is more relevant to other users

## Resources
None

## Test Plan
- Reran all written tests
- Retested all user flows that fetch /user/:id and /user/details/:id

<img width="619" height="280" alt="Screenshot 2025-07-28 at 10 34 36 AM" src="https://github.com/user-attachments/assets/f98b8128-c685-4be0-8ea4-cbf28c8fb6fa" />

