### PR TITLE
Improve messages page UX and site accessibility

### DIFF
--- a/frontend/src/components/EditProfile.tsx
+++ b/frontend/src/components/EditProfile.tsx
@@ -135,9 +135,13 @@ const EditProfile = () => {
     );
 
     const interestsInput = (
-        <label className={styles.label}>
+        <div
+            className={styles.label}
+            id="interestsLabel">
             Interests
-            <section className={styles.interestsContainer}>
+            <section
+                className={styles.interestsContainer}
+                aria-labelledby="interestsLabel">
                 {formData.interests.map((value, index, array) => (
                     <div
                         key={index}
@@ -151,7 +155,8 @@ const EditProfile = () => {
                                     array[index] === 1 ? 0 : 1,
                                 ),
                             });
-                        }}>
+                        }}
+                        aria-label={value === 1 ? "Deselect" : "Select"}>
                         <FontAwesomeIcon
                             icon={
                                 value === 1 ? faCheckCircle : faPlus
@@ -160,7 +165,7 @@ const EditProfile = () => {
                     </div>
                 ))}
             </section>
-        </label>
+        </div>
     );
 
     const bioInput = (

--- a/frontend/src/components/MapCluster.tsx
+++ b/frontend/src/components/MapCluster.tsx
@@ -81,7 +81,8 @@ const MapCluster = ({ cluster, setModalData }: MapClusterProps) => {
                         onClick={() => {
                             setModalData(user);
                             setShowingPicker(false);
-                        }}>
+                        }}
+                        aria-label={`Show profile for ${user.firstName} ${user.lastName}`}>
                         {user.firstName} {user.lastName}
                     </div>
                 ))}
@@ -95,7 +96,8 @@ const MapCluster = ({ cluster, setModalData }: MapClusterProps) => {
             <AdvancedMarker position={geoHashToLatLng(cluster.geohash)}>
                 <div
                     className={styles.cluster}
-                    onClick={handleClusterClick}>
+                    onClick={handleClusterClick}
+                    aria-label={`Cluster of ${cluster.userIds.length} users. Click for more details`}>
                     <p className={styles.number}>{cluster.userIds.length}</p>
                     {popupsDisplay}
                 </div>

--- a/frontend/src/components/MapMarker.tsx
+++ b/frontend/src/components/MapMarker.tsx
@@ -48,7 +48,8 @@ const MapMarker = ({ id, location, setModalData }: MapMarkerProps) => {
             <AdvancedMarker position={geoHashToLatLng(location)}>
                 <div
                     className={styles.marker}
-                    onClick={handleMarkerClick}>
+                    onClick={handleMarkerClick}
+                    aria-label={`Click to view profile for ${userData.firstName} ${userData.lastName}`}>
                     <FontAwesomeIcon
                         className={styles.markerIcon}
                         icon={faUser}></FontAwesomeIcon>

--- a/frontend/src/components/MapPage.tsx
+++ b/frontend/src/components/MapPage.tsx
@@ -145,14 +145,18 @@ const MapPage = () => {
     // label and slider to toggle whether the user's location is hidden from others
     const hideSlider = (
         <div className={styles.hideLocationContainer}>
-            <div className={styles.sliderLabel}>
+            <div
+                className={styles.sliderLabel}
+                id="hideLabel">
                 <h6 className={styles.sliderTitle}>Hide location?</h6>
                 <p className={styles.sliderLabelText}>
                     This will prevent any other users from seeing your location
                     on the map.
                 </p>
             </div>
-            <div className={styles.sliderContainer}>
+            <div
+                className={styles.sliderContainer}
+                aria-labelledby="hideLabel">
                 <Slider
                     value={hideLocation}
                     setValue={setHideLocation}
@@ -165,14 +169,18 @@ const MapPage = () => {
     // label and slider to pick radius in which to show other users
     const radiusSlider = (
         <div className={styles.radiusContainer}>
-            <div className={styles.sliderContainer}>
+            <div
+                className={styles.sliderContainer}
+                aria-labelledby="radiusLabel">
                 <Slider
                     value={radius}
                     setValue={setRadius}
                     options={[0.5, 1, 2, 5]}
                     optionsDisplay={["0.5mi", "1mi", "2mi", "5mi"]}></Slider>
             </div>
-            <div className={styles.sliderLabel}>
+            <div
+                className={styles.sliderLabel}
+                id="radiusLabel">
                 <h6 className={styles.sliderTitle}>Nearby radius</h6>
                 <p className={styles.sliderLabelText}>
                     Choose a radius around you in which to show other users.

--- a/frontend/src/components/Messages.tsx
+++ b/frontend/src/components/Messages.tsx
@@ -168,10 +168,16 @@ const Messages = () => {
                     className={`${styles.friend} ${friend.id === selectedFriendId ? styles.selected : ""}`}
                     onClick={() => {
                         setSelectedFriendId(friend.id);
-                    }}>
+                    }}
+                    aria-label={`${friend.id === selectedFriendId ? "Selected." : ""} View messages with ${friend.firstName} ${friend.lastName}`}
+                    tabIndex={0}>
                     <h6
                         className={styles.friendName}
-                        onClick={() => setModalData(friend)}>
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            setModalData(friend);
+                        }}
+                        aria-label={`View profile for ${friend.firstName} ${friend.lastName}`}>
                         {friend.firstName} {friend.lastName}
                     </h6>
                 </div>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -138,6 +138,7 @@ const Modal = ({ userData, setUserData }: ModalProps) => {
             <div className={styles.actionsContainer}>
                 <input
                     type="text"
+                    name="message"
                     className={styles.input}
                     value={messageText}
                     onChange={(event) => setMessageText(event.target.value)}

--- a/frontend/src/components/RecommendationPlace.tsx
+++ b/frontend/src/components/RecommendationPlace.tsx
@@ -23,7 +23,8 @@ const RecommendationPlace = ({
             <h6 className={styles.placeName}>{place.place.displayName.text}</h6>
             <button
                 className={styles.likeButton}
-                onClick={() => handleLikeClick(place)}>
+                onClick={() => handleLikeClick(place)}
+                aria-label="Like">
                 <FontAwesomeIcon icon={faThumbsUp}></FontAwesomeIcon>
             </button>
         </div>

--- a/frontend/src/css/Messages.module.css
+++ b/frontend/src/css/Messages.module.css
@@ -50,6 +50,7 @@
     font-weight: bold;
     color: var(--teal-accent);
     margin: 0;
+    width: fit-content;
 }
 
 .friendName:hover {

--- a/frontend/tests/Messages.test.tsx
+++ b/frontend/tests/Messages.test.tsx
@@ -107,7 +107,7 @@ describe("Messages", () => {
         });
 
         // click on first friend
-        fireEvent.click(friends[0]);
+        fireEvent.click(friends[0].parentElement!);
 
         // should call getMessagesBetween and render mock message
         await waitFor(() => {


### PR DESCRIPTION
## Description
- Improve selecting a friend on the messages page: the friend's name, which triggers the profile modal, no longer extends across the whole div, so it's easier to simply view the conversation with them without triggering the modal. In addition, clicking on their name will not switch the conversation view to them, since it could be confusing when this happened invisibly behind the modal.
- Fix `Messages > renders messages` test to click on div now that clicking the friend's name does not display messages
- Add `aria-label` and `aria-labelledby` to elements, especially buttons with no text content

## Milestones
- Closes #31 

## Resources
[aria-label docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
[aria-labelledby docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)

## Test Plan
- Used inspect tool to verify that ARIA labels were applied
- Tested messages page flow
