### PR TITLE
Fix bug in reset password token validation logic

### DIFF
--- a/backend/routes/resetPasswordRoutes.js
+++ b/backend/routes/resetPasswordRoutes.js
@@ -143,7 +143,7 @@ router.post("/verify", async (req, res) => {
     }
 
     // verify that given token and active token match
-    const isValidToken = bcrypt.compare(token, existingTokenData.token);
+    const isValidToken = await bcrypt.compare(token, existingTokenData.token);
 
     if (!isValidToken) {
         return res.status(401).send(invalidMessage);


### PR DESCRIPTION
## Description
- Add missing `await` before `bcrypt.compare()`; without this, tokens would not be validated correctly because a `Promise`, and thus `isValidToken`, is truthy

## Milestones
- Improves reset password stretch feature

## Resources
[bcrypt docs](https://www.npmjs.com/package/bcrypt)

## Test Plan
[Loom video](https://www.loom.com/share/c84a98feb3ac4f62b3457cb9fe3c7e72?sid=8647fbf5-7c3d-46e6-bd4f-8137547ceab1)
When I manually change the token to an incorrect string and reload, then try to change my password, it fails. I have to use the valid token to successfully change my password.
